### PR TITLE
Add type definitions to the npm package

### DIFF
--- a/project/npm/package.json
+++ b/project/npm/package.json
@@ -20,6 +20,7 @@
     "license": "Apache-2.0",
     "author": "Vizzu Kft.",
     "main": "dist/vizzu.min.js",
+    "types": "dist/vizzu.d.ts",
     "repository": {
         "type": "git",
         "url": "https://github.com/vizzuhq/vizzu-lib.git"


### PR DESCRIPTION
Without this line, the user gets and error when importing the npm package in TypeScript.
See screenshot of the error below

![image](https://user-images.githubusercontent.com/36007115/137593246-38b3a0bc-b5e9-4f45-94e5-c82e326c608f.png)
