### PR TITLE
Fix g++11 compilation + tests

### DIFF
--- a/src/apps/qtest/chart.cpp
+++ b/src/apps/qtest/chart.cpp
@@ -46,7 +46,7 @@ void TestChart::run()
 		IO::log() << "finished";
 	};
 
-	auto step6 = [=](bool)
+	auto step6 = [=, this](bool)
 	{
 		IO::log() << "step 6";
 		auto setter = chart.getChart().getSetter();
@@ -56,7 +56,7 @@ void TestChart::run()
 		chart.getChart().animate(end);
 	};
 
-	auto step5 = [=](bool)
+	auto step5 = [=, this](bool)
 	{
 		IO::log() << "step 5";
 		auto setter = chart.getChart().getSetter();
@@ -66,7 +66,7 @@ void TestChart::run()
 		chart.getChart().animate(step6);
 	};
 
-	auto step4 = [=](bool)
+	auto step4 = [=, this](bool)
 	{
 		IO::log() << "step 4";
 		auto setter = chart.getChart().getSetter();
@@ -76,7 +76,7 @@ void TestChart::run()
 		chart.getChart().animate(step5);
 	};
 
-	auto step3 = [=](bool)
+	auto step3 = [=, this](bool)
 	{
 		IO::log() << "step 3";
 		auto setter = chart.getChart().getSetter();
@@ -90,7 +90,7 @@ void TestChart::run()
 		chart.getChart().animate(step4);
 	};
 
-	auto step2 = [=](bool)
+	auto step2 = [=, this](bool)
 	{
 		IO::log() << "step 2";
 		auto setter = chart.getChart().getSetter();
@@ -112,7 +112,7 @@ void TestChart::run()
 		chart.getChart().animate(step3);
 	};
 
-	auto step1b = [=](bool)
+	auto step1b = [=, this](bool)
 	{
 		try {
 			IO::log() << "step 1b";
@@ -141,7 +141,7 @@ void TestChart::run()
 		}
 	};
 
-	auto step1 = [=](bool)
+	auto step1 = [=, this](bool)
 	{
 		IO::log() << "step 1";
 		auto setter = chart.getChart().getSetter();

--- a/src/apps/qtest/window.cpp
+++ b/src/apps/qtest/window.cpp
@@ -17,7 +17,7 @@ Window::Window(QWidget *parent) :
     ui(new Ui::Window)
 {
 	ui->setupUi(this);
-	chart.getChart().doChange = [=]() {
+	chart.getChart().doChange = [=, this]() {
 		update();
 	};
 	resize(640, 480);

--- a/src/apps/weblib/interface.cpp
+++ b/src/apps/weblib/interface.cpp
@@ -272,7 +272,7 @@ const char *Interface::dataMetaInfo()
 
 void Interface::init()
 {
-	IO::Log::set([=](const std::string &msg) {
+	IO::Log::set([=, this](const std::string &msg) {
 		if (logging) log((msg + "\n").c_str());
 	});
 

--- a/src/chart/animator/animator.cpp
+++ b/src/chart/animator/animator.cpp
@@ -32,7 +32,7 @@ void Animator::animate(
 {
 	if (running) throw std::logic_error("animation already in progress");
 
-	auto completionCallback = [=](Diag::DiagramPtr diagram, bool ok) {
+	auto completionCallback = [=, this](Diag::DiagramPtr diagram, bool ok) {
 		nextAnimation = std::make_shared<Animation>(diagram);
 		this->running = false;
 		onThisCompletes(diagram, ok);

--- a/src/chart/main/chart.cpp
+++ b/src/chart/main/chart.cpp
@@ -49,7 +49,7 @@ void Chart::setBoundRect(const Geom::Rect &rect, Gfx::ICanvas &info)
 
 void Chart::animate(OnComplete onComplete)
 {
-	auto f = [=](Diag::DiagramPtr diagram, bool ok) {
+	auto f = [=, this](Diag::DiagramPtr diagram, bool ok) {
 		actDiagram = diagram;
 		if (ok) {
 			prevOptions = *nextOptions;

--- a/src/chart/main/style.cpp
+++ b/src/chart/main/style.cpp
@@ -20,37 +20,37 @@ Font Chart::defaultFont{
 Chart Chart::def()
 {
 	return {
-		{
+	    Padding {
 			.paddingTop = Gfx::Length::Emphemeral(5.0/12.0),
 			.paddingRight = Gfx::Length::Emphemeral(5.0/12.0),
 			.paddingBottom = Gfx::Length::Emphemeral(10.0/12.0),
 			.paddingLeft = Gfx::Length::Emphemeral(5.0/12.0)
 		},
-		{
+		Box {
 			.backgroundColor = Gfx::Color::White(),
 			.borderColor = Gfx::Color::White(),
 			.borderWidth = 0,
 		},
-		{
+		Font {
 			.fontFamily = ::Anim::String("Roboto, sans-serif"),
 			.fontStyle = Gfx::Font::Style::normal,
 			.fontWeight = Gfx::Font::Weight::Normal(),
 			.fontSize = Gfx::Length::Emphemeral(1)
 		},
-		.plot = {
-			{
+		Plot {
+			Padding {
 				.paddingTop = Gfx::Length::Emphemeral(50.0/12.0),
 				.paddingRight = Gfx::Length::Emphemeral(45.0/12.0),
 				.paddingBottom = Gfx::Length::Emphemeral(60.0/12.0),
 				.paddingLeft = Gfx::Length::Emphemeral(80.0/12.0)
 			},
-			{
+			Box {
 				.backgroundColor = Gfx::Color(),
 				.borderColor = Gfx::Color(),
 				.borderWidth = 0,
 			},
-			.marker = {
-				{
+			Marker {
+				DataPoint {
 					.colorGradient = Gfx::ColorGradient({
 						{ 0.0, Gfx::Color::RGB(0x4171cd) },
 						{ 0.25, Gfx::Color::RGB(0x8536c7) },
@@ -68,32 +68,32 @@ Chart Chart::def()
 					.rectangleSpacing = ::Anim::Interpolated<std::optional<double>>
 						(std::nullopt)
 				},
-				.borderWidth = 1,
-				.borderOpacity = 1,
-				.borderOpacityMode =
+				/*.borderWidth = */ 1,
+				/*.borderOpacity = */ 1,
+				/*.borderOpacityMode = */
 					::Anim::Interpolated<Marker::BorderOpacityMode>
 					(Marker::BorderOpacityMode::premultiplied),
-				.fillOpacity = 1,
-				.guides = {
+				/*.fillOpacity = */ 1,
+				/*.guides =*/ Guide {
 					.color = Gfx::Color::Gray(0.91),
 					.lineWidth = 0.5
 				},
-				.label = {
-					{
-						{
-							{
+				MarkerLabel{
+	                OrientedLabel {
+	                    Label {
+							Padding {
 								.paddingTop = Gfx::Length::Emphemeral(5/11.0),
 								.paddingRight = Gfx::Length::Emphemeral(5/11.0),
 								.paddingBottom = Gfx::Length::Emphemeral(5/11.0),
 								.paddingLeft = Gfx::Length::Emphemeral(5/11.0)
 							},
-							{
+							Font {
 								.fontFamily = ::Anim::String(),
 								.fontStyle = Gfx::Font::Style::normal,
 								.fontWeight = Gfx::Font::Weight::Bold(),
 								.fontSize = Gfx::Length::Emphemeral(11.0/12.0)
 							},
-							{
+							Text {
 								.color = Gfx::Color(),
 								.textAlign = Anim::Interpolated<Text::TextAlign>
 									(Text::TextAlign::center),
@@ -103,34 +103,34 @@ Chart Chart::def()
 								.numberScale = ::Text::NumberScale::siSymbols
 							}
 						},
-						.orientation = Anim::Interpolated
+						Anim::Interpolated
 							<OrientedLabel::Orientation>
 							(OrientedLabel::Orientation::horizontal),
-						.angle = Geom::Angle180(),
+						Geom::Angle180(),
 					},
-					.position = Anim::Interpolated<MarkerLabel::Position>
+					Anim::Interpolated<MarkerLabel::Position>
 						(MarkerLabel::Position::center),
-					.filter = Gfx::ColorTransform::Lightness(0),
-					.format = MarkerLabel::Format::measureFirst
+					Gfx::ColorTransform::Lightness(0),
+					MarkerLabel::Format::measureFirst
 				}
 			},
-			.xAxis = {
+			Axis {
 				.color = Gfx::Color::Gray(0.8),
 				.title = {
-					{
-						{
+	                Label {
+						Padding {
 							.paddingTop = Gfx::Length::Emphemeral(24/14.0),
 							.paddingRight = Gfx::Length::Emphemeral(5/14.0),
 							.paddingBottom = Gfx::Length::Emphemeral(5/14.0),
 							.paddingLeft = Gfx::Length::Emphemeral(5/14.0)
 						},
-						{
+						Font {
 							.fontFamily = ::Anim::String(),
 							.fontStyle = Gfx::Font::Style::normal,
 							.fontWeight = Gfx::Font::Weight::Normal(),
 							.fontSize = Gfx::Length::Emphemeral(14.0/12.0)
 						},
-						{
+						Text {
 							.color = Gfx::Color::Gray(0.6),
 							.textAlign = Anim::Interpolated<Text::TextAlign>
 								(Text::TextAlign::left),
@@ -140,33 +140,33 @@ Chart Chart::def()
 							.numberScale = ::Text::NumberScale::siSymbols
 						}
 					},
-					.position = Anim::Interpolated<AxisTitle::Position>
+					Anim::Interpolated<AxisTitle::Position>
 						(AxisTitle::Position::min_edge),
-					.side = Anim::Interpolated<AxisTitle::Side>
+					Anim::Interpolated<AxisTitle::Side>
 						(AxisTitle::Side::negative),
-					.vposition = Anim::Interpolated<AxisTitle::VPosition>
+					Anim::Interpolated<AxisTitle::VPosition>
 						(AxisTitle::VPosition::middle),
-					.vside = Anim::Interpolated<AxisTitle::VSide>
+					Anim::Interpolated<AxisTitle::VSide>
 						(AxisTitle::VSide::upon),
-					.orientation = Anim::Interpolated<AxisTitle::Orientation>
+					Anim::Interpolated<AxisTitle::Orientation>
 						(AxisTitle::Orientation::horizontal)
 				},
 				.label = {
-					{
-						{
-							{
+	                OrientedLabel {
+	                    Label {
+							Padding {
 								.paddingTop = Gfx::Length::Emphemeral(8/12.0),
 								.paddingRight = Gfx::Length::Emphemeral(8/12.0),
 								.paddingBottom = Gfx::Length::Emphemeral(8/12.0),
 								.paddingLeft = Gfx::Length::Emphemeral(8/12.0)
 							},
-							{
+							Font {
 								.fontFamily = ::Anim::String(),
 								.fontStyle = Gfx::Font::Style::normal,
 								.fontWeight = Gfx::Font::Weight::Normal(),
 								.fontSize = Gfx::Length::Emphemeral(12.0/12.0)
 							},
-							{
+							Text {
 								.color = Gfx::Color::Gray(0.6),
 								.textAlign = Anim::Interpolated<Text::TextAlign>
 										(Text::TextAlign::left),
@@ -176,14 +176,14 @@ Chart Chart::def()
 								.numberScale = ::Text::NumberScale::siSymbols
 							}
 						},
-						.orientation = Anim::Interpolated
+						Anim::Interpolated
 							<OrientedLabel::Orientation>
 							(OrientedLabel::Orientation::horizontal),
-						.angle = Geom::Angle180(),
+						Geom::Angle180(),
 					},
-					.position = Anim::Interpolated<AxisLabel::Position>
+					Anim::Interpolated<AxisLabel::Position>
 						(AxisLabel::Position::min_edge),
-					.side = Anim::Interpolated<AxisLabel::Side>
+					Anim::Interpolated<AxisLabel::Side>
 						(AxisLabel::Side::negative)
 				},
 				.ticks = {
@@ -201,23 +201,23 @@ Chart Chart::def()
 					.color = Gfx::Color::Gray(0.97)
 				}
 			},
-			.yAxis = {
+			Axis {
 				.color = Gfx::Color::Gray(0.8),
 				.title = {
-					{
-						{
+					Label {
+						Padding {
 							.paddingTop = Gfx::Length::Emphemeral(5/14.0),
 							.paddingRight = Gfx::Length::Emphemeral(5/14.0),
 							.paddingBottom = Gfx::Length::Emphemeral(15/14.0),
 							.paddingLeft = Gfx::Length::Emphemeral(5/14.0)
 						},
-						{
+						Font {
 							.fontFamily = ::Anim::String(),
 							.fontStyle = Gfx::Font::Style::normal,
 							.fontWeight = Gfx::Font::Weight::Normal(),
 							.fontSize = Gfx::Length::Emphemeral(14.0/12.0)
 						},
-						{
+						Text {
 							.color = Gfx::Color::Gray(0.6),
 							.textAlign = Anim::Interpolated<Text::TextAlign>
 								(Text::TextAlign::left),
@@ -227,33 +227,33 @@ Chart Chart::def()
 							.numberScale = ::Text::NumberScale::siSymbols
 						}
 					},
-					.position = Anim::Interpolated<AxisTitle::Position>
+					Anim::Interpolated<AxisTitle::Position>
 						(AxisTitle::Position::min_edge),
-					.side = Anim::Interpolated<AxisTitle::Side>
+					Anim::Interpolated<AxisTitle::Side>
 						(AxisTitle::Side::upon),
-					.vposition = Anim::Interpolated<AxisTitle::VPosition>
+					Anim::Interpolated<AxisTitle::VPosition>
 						(AxisTitle::VPosition::end),
-					.vside = Anim::Interpolated<AxisTitle::VSide>
+					Anim::Interpolated<AxisTitle::VSide>
 						(AxisTitle::VSide::positive),
-					.orientation = Anim::Interpolated<AxisTitle::Orientation>
+					Anim::Interpolated<AxisTitle::Orientation>
 						(AxisTitle::Orientation::horizontal)
 				},
 				.label = {
-					{
-						{
-							{
+					OrientedLabel {
+						Label {
+							Padding {
 								.paddingTop = Gfx::Length::Emphemeral(8/12.0),
 								.paddingRight = Gfx::Length::Emphemeral(8/12.0),
 								.paddingBottom = Gfx::Length::Emphemeral(8/12.0),
 								.paddingLeft = Gfx::Length::Emphemeral(8/12.0)
 							},
-							{
+							Font {
 								.fontFamily = ::Anim::String(),
 								.fontStyle = Gfx::Font::Style::normal,
 								.fontWeight = Gfx::Font::Weight::Normal(),
 								.fontSize = Gfx::Length::Emphemeral(12.0/12.0)
 							},
-							{
+							Text {
 								.color = Gfx::Color::Gray(0.6),
 								.textAlign = Anim::Interpolated<Text::TextAlign>
 										(Text::TextAlign::left),
@@ -263,14 +263,14 @@ Chart Chart::def()
 								.numberScale = ::Text::NumberScale::siSymbols
 							}
 						},
-						.orientation = Anim::Interpolated
+						Anim::Interpolated
 							<OrientedLabel::Orientation>
 							(OrientedLabel::Orientation::horizontal),
-						.angle = Geom::Angle180(),
+	                    Geom::Angle180(),
 					},
-					.position = Anim::Interpolated<AxisLabel::Position>
+					Anim::Interpolated<AxisLabel::Position>
 						(AxisLabel::Position::min_edge),
-					.side = Anim::Interpolated<AxisLabel::Side>
+	                Anim::Interpolated<AxisLabel::Side>
 						(AxisLabel::Side::negative)
 				},
 				.ticks = {
@@ -288,10 +288,9 @@ Chart Chart::def()
 					.color = Gfx::Color::Gray(0.97)
 				}
 			},
-			.overflow = ::Anim::Interpolated<Overflow>
-				(Overflow::hidden)
+			::Anim::Interpolated<Overflow>(Overflow::hidden)
 		},
-		.legend = {
+		Legend {
 			{
 				.paddingTop = Gfx::Length::Emphemeral(10.0/12.0),
 				.paddingRight = Gfx::Length::Emphemeral(5.0/12.0),
@@ -303,22 +302,22 @@ Chart Chart::def()
 				.borderColor = Gfx::Color(),
 				.borderWidth = 0,
 			},
-			.width = Gfx::Length::Emphemeral(100.0/12.0),
-			.maxWidth = Gfx::Length::Relative(0.3),
-			.title = {
-				{
+			/*.width = */ Gfx::Length::Emphemeral(100.0/12.0),
+			/*.maxWidth = */ Gfx::Length::Relative(0.3),
+			/*.title = */ Label {
+				Padding {
 					.paddingTop = Gfx::Length::Emphemeral(12/14.0),
 					.paddingRight = Gfx::Length::Emphemeral(5/14.0),
 					.paddingBottom = Gfx::Length::Emphemeral(5/14.0),
 					.paddingLeft = Gfx::Length::Emphemeral(5/14.0)
 				},
-				{
+				Font {
 					.fontFamily = ::Anim::String(),
 					.fontStyle = Gfx::Font::Style::normal,
 					.fontWeight = Gfx::Font::Weight::Normal(),
 					.fontSize = Gfx::Length::Emphemeral(14.0/12.0)
 				},
-				{
+				Text {
 					.color = Gfx::Color::Gray(0.6),
 					.textAlign = Anim::Interpolated<Text::TextAlign>
 								(Text::TextAlign::left),
@@ -328,20 +327,20 @@ Chart Chart::def()
 					.numberScale = ::Text::NumberScale::siSymbols
 				},
 			},
-			.label = {
-				{
+			Label {
+				Padding {
 					.paddingTop = Gfx::Length::Emphemeral(5.0/12.0),
 					.paddingRight = Gfx::Length::Emphemeral(5/12.0),
 					.paddingBottom = Gfx::Length::Emphemeral(5/12.0),
 					.paddingLeft = Gfx::Length::Emphemeral(5/12.0)
 				},
-				{
+				Font {
 					.fontFamily = ::Anim::String(),
 					.fontStyle = Gfx::Font::Style::normal,
 					.fontWeight = Gfx::Font::Weight::Normal(),
 					.fontSize = Gfx::Length::Emphemeral(12.0/12.0)
 				},
-				{
+				Text {
 					.color = Gfx::Color::Gray(0.6),
 					.textAlign = Anim::Interpolated<Text::TextAlign>
 								(Text::TextAlign::left),
@@ -351,26 +350,26 @@ Chart Chart::def()
 					.numberScale = ::Text::NumberScale::siSymbols
 				},
 			},
-			.marker = {
+			Legend::Marker {
 				.type = ::Anim::Interpolated<Legend::Marker::Type>
 					(Legend::Marker::Type::circle),
 				.size = Gfx::Length::Emphemeral(18.0/14.0)
 			}
 		},
-		.title = {
-			{
+		Label {
+			Padding {
 				.paddingTop = Gfx::Length::Emphemeral(15.0/26.0),
 				.paddingRight = Gfx::Length::Emphemeral(10.0/26.0),
 				.paddingBottom = Gfx::Length::Emphemeral(0),
 				.paddingLeft = Gfx::Length::Emphemeral(10.0/26.0)
 			},
-			{
+			Font {
 				.fontFamily = ::Anim::String(),
 				.fontStyle = Gfx::Font::Style::normal,
 				.fontWeight = Gfx::Font::Weight::Normal(),
 				.fontSize = Gfx::Length::Emphemeral(26.0/12.0)
 			},
-			{
+			Text {
 				.color = Gfx::Color::RGB(0x494949),
 				.textAlign = Anim::Interpolated<Text::TextAlign>
 								(Text::TextAlign::center),
@@ -380,37 +379,37 @@ Chart Chart::def()
 				.numberScale = ::Text::NumberScale::siSymbols
 			},
 		},
-		.tooltip = {
-			{
+		Tooltip {
+			Font {
 				.fontFamily = ::Anim::String("Roboto, sans-serif"),
 				.fontStyle = Gfx::Font::Style::normal,
 				.fontWeight = Gfx::Font::Weight::Normal(),
 				.fontSize = 12
 			},
-			{
+			Box {
 				.backgroundColor = Gfx::Color::White(),
 				.borderColor = Gfx::Color::Gray(0.85),
 				.borderWidth = 1,
 			},
-			.layout = Anim::Interpolated<Tooltip::Layout>
+			Anim::Interpolated<Tooltip::Layout>
 				(Tooltip::Layout::multiLine),
-			.color = Gfx::Color::Gray(0.1),
-			.shadowColor = Gfx::Color(0, 0, 0, 0.04),
-			.borderRadius = 3,
-			.dropShadow = 3,
-			.arrowSize = 8,
-			.distance = 2,
-			.seriesName = ::Anim::String("")
+			/*.color = */ Gfx::Color::Gray(0.1),
+			/*.shadowColor = */ Gfx::Color(0, 0, 0, 0.04),
+			/*.borderRadius = */ 3,
+			/*.dropShadow = */ 3,
+			/*.arrowSize = */ 8,
+			/*.distance = */ 2,
+			/*.seriesName = */ ::Anim::String("")
 		},
-		.logo = {
-			{
+		Logo {
+	        Padding {
 				.paddingTop = Gfx::Length::Relative(0.475),
 				.paddingRight = Gfx::Length::Relative(0.4),
 				.paddingBottom = Gfx::Length::Relative(0.475),
 				.paddingLeft = Gfx::Length::Relative(0.4)
 			},
-			.width = Gfx::Length::Emphemeral(40.0*2900/3000/12.13526042),
-			.filter = Gfx::ColorTransform::OverrideColor(Gfx::Color::Gray(0.85))
+			/*.width = */ Gfx::Length::Emphemeral(40.0*2900/3000/12.13526042),
+			/*.filter = */ Gfx::ColorTransform::OverrideColor(Gfx::Color::Gray(0.85))
 		}
 	};
 }

--- a/src/chart/options/advancedoptions.cpp
+++ b/src/chart/options/advancedoptions.cpp
@@ -31,7 +31,7 @@ void ExistsHandler::handleExists()
 {
 	if (forcedExistsSeries)
 		options.getScales().visitAll(
-		[=](ScaleId id, const Scale& scale)
+		[=, this](ScaleId id, const Scale& scale)
 		{
 			if (scale.discretesIds().empty()
 				&& scale.continousId()

--- a/src/chart/options/operations.cpp
+++ b/src/chart/options/operations.cpp
@@ -58,7 +58,7 @@ void Operations::removeSeries(const Data::SeriesIndex &index)
 	const auto &options = setter->getOptions();
 
 	options.getScales().visitAll(
-	    [=](ScaleId id, const Scale &scale)
+	    [=, this](ScaleId id, const Scale &scale)
 	    {
 		    if (scale.isSeriesUsed(index))
 			    setter->deleteSeries(id, index);

--- a/src/chart/options/optionsimplifier.cpp
+++ b/src/chart/options/optionsimplifier.cpp
@@ -22,7 +22,7 @@ void OptionSimplifier::removeNotUsedSeries()
 	{
 		if (stat.usedValueCntOf(index) < 2)
 		{
-			options.getScales().visitAll([=](ScaleId id, const Scale &scale)
+			options.getScales().visitAll([=, this](ScaleId id, const Scale &scale)
 			{
 				if (scale.isSeriesUsed(index))
 					setter->deleteSeries(id, index);

--- a/src/chart/options/scalerange.cpp
+++ b/src/chart/options/scalerange.cpp
@@ -40,6 +40,7 @@ double ScaleRange::getExtrema(
 		case ET::absolute: return (*extrema).value;
 		case ET::relative: return originalRange.scale((*extrema).value / 100.0);
 		case ET::minOffset: return originalRange.getMin() + (*extrema).value;
-		case ET::maxOffset: return originalRange.getMax() + (*extrema).value;
+		case ET::maxOffset: default:
+		    return originalRange.getMax() + (*extrema).value;
 	}
 }


### PR DESCRIPTION
- implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20
- control reaches end of non-void function
- Order of evaluation of function arguments is unspecified
- either all initializer clauses should be designated or none of them should be 
  **I kept some initialization comments for non-strongly typed variables in style.cpp.**
  - https://stackoverflow.com/questions/67005837/how-to-combine-base-class-explicit-constructor-and-designated-initialization-in
  - https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2287r1.html)