### PR TITLE
Release notes tailored.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   system change.
 - Fixed unintentional separate animation steps for specific dimension change
   animations.
-- Fixed JS exception mishandling as C++ exception when c++ segfault happens.
+- Fixed JS exception mishandling as C++ exception when thrown from webassembly.
 
 ### Added
 


### PR DESCRIPTION
Hopefully, there was no segfault in the previous release, but still, JS callbacks registered in the webassembly code could have been thrown JS exceptions.