### PR TITLE
Fix code reference links

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,39 +9,39 @@ our [Tutorial](../tutorial/index.md) first.
 
 ## Library Overview
 
-The main entry point of the library is the [Vizzu](./classes/vizzu.Vizzu.md)
-class, and its most important component is the
-[animate](./classes/vizzu.Vizzu.md#animate) method:
+The main entry point of the library is the [Vizzu](./classes/Vizzu.md) class,
+and its most important component is the [animate](./classes/Vizzu.md#animate)
+method:
 
-- [Vizzu](./classes/vizzu.Vizzu.md) class
-  - [constructor()](./classes/vizzu.Vizzu.md#constructor)
-  - [animate](./classes/vizzu.Vizzu.md#animate) (
-    [Anim.Target](./interfaces/vizzu.Anim.Target.md) ,
-    [Anim.Options](./interfaces/vizzu.Anim.Options.md) ) :
-    [Anim.Completing](./interfaces/vizzu.Anim.Completing.md)
+- [Vizzu](./classes/Vizzu.md) class
+  - [constructor()](./classes/Vizzu.md#constructor)
+  - [animate](./classes/Vizzu.md#animate) (
+    [Anim.Target](./interfaces/Anim.Target.md) ,
+    [Anim.Options](./interfaces/Anim.Options.md) ) :
+    [Anim.Completing](./interfaces/Anim.Completing.md)
 
 The `animate` method's main parameter is the
-[Anim.Target](./interfaces/vizzu.Anim.Target.md) interface, which contains the
+[Anim.Target](./interfaces/Anim.Target.md) interface, which contains the
 configuration of the chart, the underlying data, and the chart's style settings:
 
-- [Anim.Target](./interfaces/vizzu.Anim.Target.md)
-  - [Data.Set](./modules/vizzu.Data.md#Set)
-  - [Config.Chart](./interfaces/vizzu.Config.Chart.md)
-    - [Config.Channels](./interfaces/vizzu.Config.Channels.md)
-  - [Styles.Chart](./interfaces/vizzu.Styles.Chart.md)
-    - [Styles.Plot](./interfaces/vizzu.Styles.Plot.md)
-      - [Styles.Marker](./interfaces/vizzu.Styles.Marker.md)
-      - [Styles.Axis](./interfaces/vizzu.Styles.Axis.md)
-    - [Styles.Legend](./interfaces/vizzu.Styles.Legend.md)
-    - [Styles.Tooltip](./interfaces/vizzu.Styles.Tooltip.md)
+- [Anim.Target](./interfaces/Anim.Target.md)
+  - [Data.Set](./modules/Data.md#Set)
+  - [Config.Chart](./interfaces/Config.Chart.md)
+    - [Config.Channels](./interfaces/Config.Channels.md)
+  - [Styles.Chart](./interfaces/Styles.Chart.md)
+    - [Styles.Plot](./interfaces/Styles.Plot.md)
+      - [Styles.Marker](./interfaces/Styles.Marker.md)
+      - [Styles.Axis](./interfaces/Styles.Axis.md)
+    - [Styles.Legend](./interfaces/Styles.Legend.md)
+    - [Styles.Tooltip](./interfaces/Styles.Tooltip.md)
 
 ## Details
 
 You can find all interface declarations and types under these namespaces.
 
-- [Data](./modules/vizzu.Data.md) - Data structure and operations
-- [Config](./modules/vizzu.Config.md) - Configuration settings of your charts
-- [Style](./modules/vizzu.Styles.md) - Style settings
-- [Anim](./modules/vizzu.Anim.md) - Animation settings
-- [Events](./modules/vizzu.Event.md) - Event handling
-- [Presets](./modules/presets.md) - Preset chart configurations
+- [Data](./modules/Data.md) - Data structure and operations
+- [Config](./modules/Config.md) - Configuration settings of your charts
+- [Style](./modules/Styles.md) - Style settings
+- [Anim](./modules/Anim.md) - Animation settings
+- [Events](./modules/Event.md) - Event handling
+- [Presets](./modules/Presets.md) - Preset chart configurations

--- a/docs/tutorial/axes_title_tooltip.md
+++ b/docs/tutorial/axes_title_tooltip.md
@@ -131,7 +131,7 @@ chart.feature('tooltip', true)
 
 !!! note
     Calls to this method before the
-    [library initialization](../reference/classes/vizzu.Vizzu.md#initializing)
+    [library initialization](../reference/classes/Vizzu.md#initializing)
     completed will fail.
 
 <script src="../axes_title_tooltip.js"></script>

--- a/docs/tutorial/color_palette_fonts.md
+++ b/docs/tutorial/color_palette_fonts.md
@@ -140,6 +140,6 @@ chart.animate({
 ```
 
 For information on all available style parameters see the [Style](./style.md)
-chapter or the [Code reference](../reference/interfaces/vizzu.Styles.Chart.md).
+chapter or the [Code reference](../reference/interfaces/Styles.Chart.md).
 
 <script src="../color_palette_fonts.js"></script>


### PR DESCRIPTION
Code ref has undergone some changes after being generated from the YAML file, and instead of creating two .d.ts files, only one was generated.

Modifications in vizzu-lib-doc: https://github.com/vizzuhq/vizzu-lib-doc/pull/45