### PR TITLE
Allows to run manual offline

### DIFF
--- a/test/integration/modules/console/console.test.js
+++ b/test/integration/modules/console/console.test.js
@@ -104,17 +104,9 @@ describe("new Console(logPrefix, logPath|undefined).cnsl.log()", () => {
 
   afterEach(() => {
     if (path.basename(path.dirname(logFile)) === "logPath") {
-      fs.rm(path.dirname(logFile), { force: true, recursive: true }, (err) => {
-        if (err) {
-          throw err;
-        }
-      });
+      fs.rmSync(path.dirname(logFile), { force: true, recursive: true });
     } else {
-      fs.rm(logFile, { force: true, recursive: true }, (err) => {
-        if (err) {
-          throw err;
-        }
-      });
+      fs.rmSync(logFile, { force: true, recursive: true });
     }
   });
 

--- a/test/integration/modules/integration-test/test-case/test-cases.test.js
+++ b/test/integration/modules/integration-test/test-case/test-cases.test.js
@@ -489,9 +489,5 @@ describe("getTestCases()", () => {
 });
 
 afterAll(() => {
-  fs.rm(suites, { force: true, recursive: true }, (err) => {
-    if (err) {
-      throw err;
-    }
-  });
+  fs.rmSync(suites, { force: true, recursive: true  });
 });

--- a/test/integration/modules/vizzu/vizzu-url.test.js
+++ b/test/integration/modules/vizzu/vizzu-url.test.js
@@ -303,7 +303,7 @@ describe("resolveVizzuUrl()", () => {
         return new Promise((resolve, reject) => {
           let local = "./test_report";
           let rmVizzuJsReady = new Promise((resolve, reject) => {
-            fs.rm(local + VizzuUrl.getVizzuJs(), { force: true }, (err) => {
+            fs.rm(local + VizzuUrl.getVizzuJs(), { force: true, recursive: true  }, (err) => {
               if (err) {
                 return reject(err);
               }
@@ -311,7 +311,7 @@ describe("resolveVizzuUrl()", () => {
             });
           });
           let rmVizzuMinJsReady = new Promise((resolve, reject) => {
-            fs.rm(local + VizzuUrl.getVizzuMinJs(), { force: true }, (err) => {
+            fs.rm(local + VizzuUrl.getVizzuMinJs(), { force: true, recursive: true  }, (err) => {
               if (err) {
                 return reject(err);
               }

--- a/test/integration/modules/vizzu/vizzu-version.js
+++ b/test/integration/modules/vizzu/vizzu-version.js
@@ -80,7 +80,20 @@ class VizzuVersion {
           });
         })
         .catch((err) => {
-          return resolve(this.getPublicBetaList());
+          console.error("failed to fetch cdn lib list");
+          return resolve([]);
+        });
+    });
+  }
+
+  static isUrlAvailable(url) {
+    return new Promise((resolve, reject) => {
+      fetch(url, { method: 'HEAD' })
+        .then((response) => {
+          resolve(response.status === 200);
+        })
+        .catch((error) => {
+          resolve(false);
         });
     });
   }


### PR DESCRIPTION
To run integration test offline, for now use this workaround:
node test.js --vizzu-ref /example/lib/vizzu.js
(because failed to fetch default ref vizzu)