### PR TITLE
Integration test log failed tests separately

### DIFF
--- a/test/integration/modules/integration-test/test-case/test-case-result.js
+++ b/test/integration/modules/integration-test/test-case/test-case-result.js
@@ -5,7 +5,6 @@ const path = require("path");
 const fs = require("fs");
 
 const TestEnv = require("../../../modules/integration-test/test-env.js");
-const VizzuUrl = require("../../../modules/vizzu/vizzu-url.js");
 
 class TestCaseResult {
   #cnsl;
@@ -181,7 +180,7 @@ class TestCaseResult {
     this.#testCaseObj.testSuiteResults.WARNING.push(
       this.#testCaseObj.testCase.testName
     );
-    this.#testCaseObj.testSuiteResults.MANUAL.push(this.#testCaseObj.testCase);
+    this.#createTestCaseResultManual();
     this.#cnsl.log(
       (
         "[ " +
@@ -216,9 +215,7 @@ class TestCaseResult {
     this.#testCaseObj.testSuiteResults.FAILED.push(
       this.#testCaseObj.testCase.testName
     );
-    this.#testCaseObj.testSuiteResults.MANUAL.push(
-      this.#testCaseObj.testCase
-    );
+    this.#createTestCaseResultManual();
     this.#createTestCaseResultErrorMsg();
     if (failureMsgs) {
       failureMsgs.forEach(failureMsg => {
@@ -231,7 +228,7 @@ class TestCaseResult {
     this.#testCaseObj.testSuiteResults.FAILED.push(
       this.#testCaseObj.testCase.testName
     );
-    this.#testCaseObj.testSuiteResults.MANUAL.push(this.#testCaseObj.testCase);
+    this.#createTestCaseResultManual();
     this.#createTestCaseResultErrorMsg();
   }
 
@@ -272,6 +269,16 @@ class TestCaseResult {
         );
       });
     }
+  }
+
+  #createTestCaseResultManual() {
+    this.#testCaseObj.testSuiteResults.MANUAL.push(this.#testCaseObj.testCase);
+    let formatted = path.relative(
+      TestEnv.getTestSuitePath(),
+      path.join(TestEnv.getWorkspacePath(), this.#testCaseObj.testCase.testName)
+    );
+    this.#testCaseObj.testSuiteResults.MANUAL_FORMATTED.push(formatted);
+    this.#cnsl.writeFailure(" " + formatted);
   }
 
   #deleteTestCaseResult() {

--- a/test/integration/modules/integration-test/test-console.js
+++ b/test/integration/modules/integration-test/test-console.js
@@ -1,10 +1,13 @@
 const path = require("path");
+const fs = require("fs");
 
 const TestEnv = require("../../modules/integration-test/test-env.js");
 const Console = require("../../modules/console/console.js");
 
 class TestConsole extends Console {
   #testSuiteLogPath;
+  #testSuiteFailuresPath;
+  #testSuiteFailuresPathReady;
 
   #testStatusPad = 8;
   #testNumberPad = 0;
@@ -17,9 +20,15 @@ class TestConsole extends Console {
         TestEnv.getTestSuiteReportPath(),
         pathPrefix
       );
+      var testSuiteFailuresPath = path.join(
+        TestEnv.getTestSuiteReportPath(),
+        "failures.log"
+      );
     }
     super(filePrefix, testSuiteLogPath);
     this.#testSuiteLogPath = testSuiteLogPath;
+    this.#testSuiteFailuresPath = testSuiteFailuresPath;
+    this.#testSuiteFailuresPathReady = this.#createFailuresLog();
   }
 
   getTestSuiteLogPath() {
@@ -48,6 +57,47 @@ class TestConsole extends Console {
       throw new Error("testNumberPad is integer");
     }
     this.#testNumberPad = testNumberPad;
+  }
+
+  #createFailuresLog() {
+    return new Promise((resolve, reject) => {
+      if (this.#testSuiteFailuresPath) {
+        fs.mkdir(path.dirname(this.#testSuiteFailuresPath), { recursive: true }, (err) => {
+          if (err) {
+            console.error('Failed to create directory:', err);
+            reject(err);
+          } else {
+            fs.writeFile(this.#testSuiteFailuresPath, '', { flag: 'w' }, (err) => {
+              if (err) {
+                console.error('Failed to write file:', err);
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+          }
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  writeFailure(line) {
+    if (this.#testSuiteFailuresPath) {
+      this.#testSuiteFailuresPathReady.then(() => {
+        return new Promise((resolve, reject) => {
+          fs.writeFile(this.#testSuiteFailuresPath, line, { flag: 'a' }, (err) => {
+            if (err) {
+              console.error('Failed to write file:', err);
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
+        });
+      });
+    }
   }
 }
 

--- a/test/integration/modules/integration-test/test-suite-result.js
+++ b/test/integration/modules/integration-test/test-suite-result.js
@@ -29,15 +29,8 @@ class TestSuiteResult {
   createTestSuiteResult() {
     this.#createNewConfig();
     if (this.#testSuiteResults.MANUAL.length != 0) {
-      const manualTestCases = [];
       this.#cnsl.log("\n");
       this.#testSuiteResults.MANUAL.forEach((testCase) => {
-        manualTestCases.push(
-          path.relative(
-            TestEnv.getTestSuitePath(),
-            path.join(TestEnv.getWorkspacePath(), testCase.testName)
-          )
-        );
         this.#cnsl.log(
           "".padEnd(this.#cnsl.getTestStatusPad() + 5, " ") +
             path.relative(
@@ -61,7 +54,7 @@ class TestSuiteResult {
         "".padEnd(this.#cnsl.getTestStatusPad() + 5, " ") +
           "node man.js" +
           " " +
-          manualTestCases.map((s) => `'${s}'`).join(" ")
+          this.#testSuiteResults.MANUAL_FORMATTED.map((s) => `'${s}'`).join(" ")
       );
     }
     this.#testSuiteResults.TIME.END = Math.round(Date.now() / 1000);

--- a/test/integration/modules/integration-test/test-suite.js
+++ b/test/integration/modules/integration-test/test-suite.js
@@ -46,6 +46,7 @@ class TestSuite {
     TIME: { START: Math.round(Date.now() / 1000), END: 0 },
     FINISHED: 0,
     MANUAL: [],
+    MANUAL_FORMATTED: [],
     RESULTS: {},
   };
 


### PR DESCRIPTION
usage:

$ node test.js
… running tests
^C --- user interrupt after some tests failed because no need now to wait for all

$ cat test_report/failures.log | xargs node man.js