### PR TITLE
Manual speed up test cases loading and coloring test cases by results

### DIFF
--- a/test/integration/modules/integration-test/test-case/test-case-result.js
+++ b/test/integration/modules/integration-test/test-case/test-case-result.js
@@ -82,6 +82,7 @@ class TestCaseResult {
     this.#testCaseObj.testSuiteResults.PASSED.push(
       this.#testCaseObj.testCase.testName
     );
+    this.#cnsl.writePassedLog(" " + this.#getFormattedTestName());
     this.#cnsl.log(
       ("[ " + "PASSED".padEnd(this.#cnsl.getTestStatusPad(), " ") + " ] ")
         .success +
@@ -180,6 +181,7 @@ class TestCaseResult {
     this.#testCaseObj.testSuiteResults.WARNING.push(
       this.#testCaseObj.testCase.testName
     );
+    this.#cnsl.writeWarningsLog(" " + this.#getFormattedTestName());
     this.#createTestCaseResultManual();
     this.#cnsl.log(
       (
@@ -215,6 +217,7 @@ class TestCaseResult {
     this.#testCaseObj.testSuiteResults.FAILED.push(
       this.#testCaseObj.testCase.testName
     );
+    this.#cnsl.writeFailedLog(" " + this.#getFormattedTestName());
     this.#createTestCaseResultManual();
     this.#createTestCaseResultErrorMsg();
     if (failureMsgs) {
@@ -228,6 +231,7 @@ class TestCaseResult {
     this.#testCaseObj.testSuiteResults.FAILED.push(
       this.#testCaseObj.testCase.testName
     );
+    this.#cnsl.writeFailedLog(" " + this.#getFormattedTestName());
     this.#createTestCaseResultManual();
     this.#createTestCaseResultErrorMsg();
   }
@@ -273,12 +277,9 @@ class TestCaseResult {
 
   #createTestCaseResultManual() {
     this.#testCaseObj.testSuiteResults.MANUAL.push(this.#testCaseObj.testCase);
-    let formatted = path.relative(
-      TestEnv.getTestSuitePath(),
-      path.join(TestEnv.getWorkspacePath(), this.#testCaseObj.testCase.testName)
-    );
+    let formatted = this.#getFormattedTestName()
     this.#testCaseObj.testSuiteResults.MANUAL_FORMATTED.push(formatted);
-    this.#cnsl.writeFailure(" " + formatted);
+    this.#cnsl.writeFailuresLog(" " + formatted);
   }
 
   #deleteTestCaseResult() {
@@ -300,6 +301,13 @@ class TestCaseResult {
         return resolve();
       });
     });
+  }
+
+  #getFormattedTestName() {
+    return path.relative(
+      TestEnv.getTestSuitePath(),
+      path.join(TestEnv.getWorkspacePath(), this.#testCaseObj.testCase.testName)
+    );
   }
 
   #createImage(data, fileAdd) {

--- a/test/integration/modules/manual/client/index.js
+++ b/test/integration/modules/manual/client/index.js
@@ -133,8 +133,8 @@ function populateLibs() {
     .then((data) => {
       for (let name in data) {
         let url = data[name];
-        vizzuUrl.innerHTML += `<option value='${url}'>${name}</option>`;
-        vizzuRef.innerHTML += `<option value='${url}'>${name}</option>`;
+        vizzuUrl.appendChild(getVizzuOption(url, name));
+        vizzuRef.appendChild(getVizzuOption(url, name));
       }
       let lastSelected = localStorage.getItem("vizzuUrl");
       if (urlVizzuUrl) {
@@ -158,6 +158,14 @@ function populateLibs() {
     });
 }
 
+function getVizzuOption(url, name) {
+  const option = document.createElement('option');
+  option.value = url;
+  const text = document.createTextNode(name);
+  option.appendChild(text);
+  return option
+}
+
 function populateCases() {
   fetch("/getTestList")
     .then((response) => response.json())
@@ -167,13 +175,14 @@ function populateCases() {
         let actcase = JSON.stringify(data[i]);
         if (
           data[i].testFile === urlTestFile &&
-          data[i].testIndex == urlTestIndex
+          data[i].testIndex === urlTestIndex
         ) {
           lastSelected = actcase;
         }
         let actcaseName = data[i].testName;
+        let actcaseResult = data[i].testResult;
         let selected = i == 0 ? 'selected="selected"' : "";
-        testCase.innerHTML += `<option ${selected} value='${actcase}'>${actcaseName}</option>`;
+        testCase.appendChild(getTestCaseOption(actcase, actcaseName, actcaseResult, selected));
       }
       if (lastSelected === "") lastSelected = JSON.stringify(data[0]);
       testCase.value = lastSelected;
@@ -181,6 +190,29 @@ function populateCases() {
       setupSelects();
       update();
     });
+}
+
+function getTestCaseOption(testCase, testCaseName, testCaseResult, selected) {
+  const option = document.createElement('option');
+  option.setAttribute('style', getTestCaseStyle(testCaseResult));
+  option.value = testCase;
+  option.selected = selected;
+  let textValue = testCaseName;
+  if (testCaseResult) textValue = `${testCaseName} | ${testCaseResult}`;
+  const text = document.createTextNode(textValue);
+  option.appendChild(text);
+  return option;
+}
+
+function getTestCaseStyle(testCaseResult) {
+  if (testCaseResult === "PASS") {
+    return "background-color: rgba(152, 251, 152, 0.8) !important;";
+  } else if (testCaseResult === "FAIL") {
+    return "background-color: rgba(255, 153, 153, 0.8) !important;";
+  } else if (testCaseResult === "WARN") {
+    return "background-color: rgba(255, 255, 153, 0.8) !important;";
+  }
+  return ";"
 }
 
 populateLibs();


### PR DESCRIPTION
speed up: replace `innerHTML +=` to `appendChild`
color:
![Screenshot from 2023-07-09 13-19-52](https://github.com/vizzuhq/vizzu-lib/assets/61405792/db00dac8-81d4-4dc7-bb92-94a505f04e05)
