### PR TITLE
Options refactor

### DIFF
--- a/src/apps/weblib/interface.cpp
+++ b/src/apps/weblib/interface.cpp
@@ -2,8 +2,8 @@
 
 #include <span>
 
-#include "base/io/log.h"
 #include "base/conv/auto_json.h"
+#include "base/io/log.h"
 
 #include "interfacejs.h"
 #include "jscriptcanvas.h"

--- a/src/base/conv/auto_json.h
+++ b/src/base/conv/auto_json.h
@@ -29,7 +29,7 @@ concept Optional =
 	       *val;
        };
 
-template <class T> concept Tuple = sizeof(std::tuple_size<T>) > 0;
+template <class T> concept Tuple = sizeof(std::tuple_size<T>) != 0;
 
 template <class T>
 concept Pair = Tuple<T> && std::tuple_size_v<T> == 2;
@@ -244,7 +244,7 @@ struct JSONObj : JSON
 
 template <class T> inline void JSON::dynamicObj(const T &val) const
 {
-	JSONObj j{json};
+	JSONObj j{json}; // NOLINT
 	for (const auto &[k, v] : val) { j(toString(k), v); }
 }
 

--- a/src/chart/animator/animation.cpp
+++ b/src/chart/animator/animation.cpp
@@ -83,8 +83,8 @@ void Animation::addKeyframe(const Gen::PlotPtr &next,
 		    !target->getOptions()->getChannels().anyAxisSet()
 		    && next->getOptions()->getChannels().anyAxisSet();
 
-		auto geometryChanges = target->getOptions()->shapeType
-		                    != next->getOptions()->shapeType;
+		auto geometryChanges = target->getOptions()->geometry
+		                    != next->getOptions()->geometry;
 
 		auto basedOnSource =
 		    loosingCoordsys || (!gainingCoordsys && geometryChanges);

--- a/src/chart/animator/morph.cpp
+++ b/src/chart/animator/morph.cpp
@@ -68,8 +68,8 @@ void CoordinateSystem::transform(const Gen::Options &source,
     Gen::Options &actual,
     double factor) const
 {
-	actual.polar =
-	    interpolate(source.polar, target.polar, factor);
+	actual.coordSystem =
+	    interpolate(source.coordSystem, target.coordSystem, factor);
 	actual.angle =
 	    interpolate(source.angle, target.angle, factor);
 }

--- a/src/chart/animator/morph.cpp
+++ b/src/chart/animator/morph.cpp
@@ -99,8 +99,8 @@ void Shape::transform(const Gen::Options &source,
     Gen::Options &actual,
     double factor) const
 {
-	actual.shapeType = interpolate(source.shapeType,
-	    target.shapeType,
+	actual.geometry = interpolate(source.geometry,
+	    target.geometry,
 	    factor);
 }
 
@@ -148,9 +148,9 @@ void Connection::transform(const Gen::Options &source,
     double factor) const
 {
 	auto sourceIsConnecting =
-	    Vizzu::Gen::isConnecting(source.shapeType.get());
+	    Vizzu::Gen::isConnecting(source.geometry.get());
 	auto targetIsConnecting =
-	    Vizzu::Gen::isConnecting(target.shapeType.get());
+	    Vizzu::Gen::isConnecting(target.geometry.get());
 
 	if (sourceIsConnecting && !targetIsConnecting) {
 		actual.horizontal = source.horizontal;

--- a/src/chart/animator/planner.cpp
+++ b/src/chart/animator/planner.cpp
@@ -245,7 +245,7 @@ void Planner::calcNeeded()
 	animNeeded[SectionId::color] = needColor();
 
 	animNeeded[SectionId::coordSystem] =
-	    srcOpt->polar != trgOpt->polar
+	    srcOpt->coordSystem != trgOpt->coordSystem
 	    || srcOpt->angle != trgOpt->angle;
 
 	animNeeded[SectionId::geometry] =

--- a/src/chart/animator/planner.cpp
+++ b/src/chart/animator/planner.cpp
@@ -101,11 +101,11 @@ void Planner::createPlan(const Gen::Plot &source,
 		addMorph(SectionId::coordSystem, std::max(step, posDuration));
 
 		const auto &geomEasing =
-		    srcOpt->shapeType == Gen::ShapeType::circle   ? in3
-		    : trgOpt->shapeType == Gen::ShapeType::circle ? out3
-		    : srcOpt->shapeType == Gen::ShapeType::line   ? in3
-		    : trgOpt->shapeType == Gen::ShapeType::line   ? out3
-		                                                  : inOut5;
+		    srcOpt->geometry == Gen::ShapeType::circle   ? in3
+		    : trgOpt->geometry == Gen::ShapeType::circle ? out3
+		    : srcOpt->geometry == Gen::ShapeType::line   ? in3
+		    : trgOpt->geometry == Gen::ShapeType::line   ? out3
+		                                                 : inOut5;
 
 		addMorph(SectionId::geometry,
 		    std::max(step, posDuration),
@@ -249,7 +249,7 @@ void Planner::calcNeeded()
 	    || srcOpt->angle != trgOpt->angle;
 
 	animNeeded[SectionId::geometry] =
-	    srcOpt->shapeType != trgOpt->shapeType;
+	    srcOpt->geometry != trgOpt->geometry;
 
 	animNeeded[SectionId::y] = needVertical();
 	animNeeded[SectionId::x] = needHorizontal();
@@ -282,8 +282,8 @@ bool Planner::positionMorphNeeded() const
 {
 	typedef Gen::ShapeType ST;
 
-	auto &srcShape = source->getOptions()->shapeType;
-	auto &trgShape = target->getOptions()->shapeType;
+	auto &srcShape = source->getOptions()->geometry;
+	auto &trgShape = target->getOptions()->geometry;
 
 	auto anyCircle = srcShape == ST::circle || trgShape == ST::circle;
 

--- a/src/chart/generator/guides.cpp
+++ b/src/chart/generator/guides.cpp
@@ -31,8 +31,8 @@ bool GuidesByAxis::operator==(const GuidesByAxis &other) const
 void Guides::init(const Axises &axises, const Options &options)
 {
 	auto isCircle =
-	    options.shapeType.get() == ShapeType::circle;
-	auto isLine = options.shapeType.get() == ShapeType::line;
+	    options.geometry.get() == ShapeType::circle;
+	auto isLine = options.geometry.get() == ShapeType::line;
 	auto isHorizontal = static_cast<bool>(options.horizontal);
 	auto yIsMeasure = static_cast<bool>(
 	    axises.at(ChannelId::y).enabled.calculate<Math::FuzzyBool>());
@@ -79,7 +79,7 @@ void Guides::init(const Axises &axises, const Options &options)
 
 	auto stretchedPolar =
 	    isPolar && !yIsMeasure
-	    && (options.alignType == Base::Align::Type::stretch);
+	    && (options.align == Base::Align::Type::stretch);
 
 	y.labels = yOpt.axisLabels.getValue(
 	    !stretchedPolar

--- a/src/chart/generator/guides.cpp
+++ b/src/chart/generator/guides.cpp
@@ -38,7 +38,7 @@ void Guides::init(const Axises &axises, const Options &options)
 	    axises.at(ChannelId::y).enabled.calculate<Math::FuzzyBool>());
 	auto xIsMeasure = static_cast<bool>(
 	    axises.at(ChannelId::x).enabled.calculate<Math::FuzzyBool>());
-	auto isPolar = static_cast<bool>(options.polar);
+	auto isPolar = options.coordSystem.get() == CoordSystem::polar;
 
 	const auto &xOpt = options.getChannels().at(ChannelId::x);
 	const auto &yOpt = options.getChannels().at(ChannelId::y);

--- a/src/chart/generator/marker.cpp
+++ b/src/chart/generator/marker.cpp
@@ -67,7 +67,7 @@ Marker::Marker(const Options &options,
 
 	mainId = Id(data, options.mainAxis().dimensionIds, index);
 
-	auto stackInhibitingShape = options.shapeType == ShapeType::area;
+	auto stackInhibitingShape = options.geometry == ShapeType::area;
 	if (stackInhibitingShape) {
 		Data::SeriesList subIds(options.subAxis().dimensionIds);
 		subIds.remove(options.mainAxis().dimensionIds);

--- a/src/chart/generator/plot.cpp
+++ b/src/chart/generator/plot.cpp
@@ -113,7 +113,7 @@ Plot::Plot(const Data::DataTable &dataTable,
 	if (gotSpecLayout) {
 		calcDimensionAxises(dataTable);
 		normalizeColors();
-		if (options->shapeType != ShapeType::circle)
+		if (options->geometry != ShapeType::circle)
 			normalizeSizes();
 		calcAxises(dataTable);
 	}
@@ -315,7 +315,7 @@ Axis Plot::calcAxis(ChannelId type, const Data::DataTable &dataTable)
 		                                         : scale.title;
 
 		if (type == options->subAxisType()
-		    && options->alignType == Base::Align::Type::stretch) {
+		    && options->align == Base::Align::Type::stretch) {
 			return {Math::Range<double>(0, 100),
 			    title,
 			    "%",
@@ -397,12 +397,12 @@ void Plot::calcDimensionAxis(ChannelId type,
 
 void Plot::addAlignment()
 {
-	if (static_cast<bool>(options->splitted)) return;
+	if (static_cast<bool>(options->split)) return;
 
 	auto &axis = axises.at(options->subAxisType());
 	if (axis.range.getMin() < 0) return;
 
-	if (options->alignType == Base::Align::Type::none) return;
+	if (options->align == Base::Align::Type::none) return;
 
 	for (auto &bucketIt : subBuckets) {
 		Math::Range<double> range;
@@ -414,7 +414,7 @@ void Plot::addAlignment()
 			range.include(size);
 		}
 
-		Base::Align aligner(options->alignType,
+		Base::Align aligner(options->align,
 		    Math::Range(0.0, 1.0));
 		auto transform = aligner.getAligned(range) / range;
 
@@ -431,10 +431,10 @@ void Plot::addAlignment()
 
 void Plot::addSeparation()
 {
-	if (static_cast<bool>(options->splitted)) {
-		auto align = options->alignType == Base::Align::Type::none
+	if (static_cast<bool>(options->split)) {
+		auto align = options->align == Base::Align::Type::none
 		               ? Base::Align::Type::min
-		               : options->alignType;
+		               : options->align;
 
 		std::vector<Math::Range<double>> ranges(mainBuckets.size(),
 		    Math::Range(0.0, 0.0));
@@ -481,8 +481,8 @@ void Plot::addSeparation()
 
 void Plot::normalizeSizes()
 {
-	if (options->shapeType == ShapeType::circle
-	    || options->shapeType == ShapeType::line) {
+	if (options->geometry == ShapeType::circle
+	    || options->geometry == ShapeType::line) {
 		Math::Range<double> size;
 
 		for (auto &marker : markers)

--- a/src/chart/generator/plot.cpp
+++ b/src/chart/generator/plot.cpp
@@ -201,7 +201,7 @@ Plot::sortedBuckets(const Buckets &buckets, bool main)
 		}
 	}
 
-	if (main && options->sorted) {
+	if (main && options->sorted == Sort::byValue) {
 		std::sort(sorted.begin(),
 		    sorted.end(),
 		    [=](const std::pair<uint64_t, double> &a,

--- a/src/chart/generator/plot.cpp
+++ b/src/chart/generator/plot.cpp
@@ -201,7 +201,7 @@ Plot::sortedBuckets(const Buckets &buckets, bool main)
 		}
 	}
 
-	if (main && options->sorted == Sort::byValue) {
+	if (main && options->sort == Sort::byValue) {
 		std::sort(sorted.begin(),
 		    sorted.end(),
 		    [=](const std::pair<uint64_t, double> &a,

--- a/src/chart/main/chart.cpp
+++ b/src/chart/main/chart.cpp
@@ -22,7 +22,7 @@ Chart::Chart() :
 	nextOptions = std::make_shared<Gen::Options>();
 
 	animator->onDraw.attach(
-	    [&](const Gen::PlotPtr& actPlot)
+	    [&](const Gen::PlotPtr &actPlot)
 	    {
 		    this->actPlot = actPlot;
 		    if (onChanged) onChanged();
@@ -56,9 +56,9 @@ void Chart::setBoundRect(const Geom::Rect &rect, Gfx::ICanvas &info)
 	}
 }
 
-void Chart::animate(const OnComplete& onComplete)
+void Chart::animate(const OnComplete &onComplete)
 {
-	auto f = [=, this](const Gen::PlotPtr& plot, bool ok)
+	auto f = [=, this](const Gen::PlotPtr &plot, bool ok)
 	{
 		actPlot = plot;
 		if (ok) {
@@ -105,9 +105,11 @@ void Chart::draw(Gfx::ICanvas &canvas) const
 	if (actPlot
 	    && (!events.draw.begin
 	        || events.draw.begin->invoke(
-	            Util::EventDispatcher::Params{}))) 
-	{
-		Draw::DrawingContext context(canvas, layout, events.draw, *actPlot);
+	            Util::EventDispatcher::Params{}))) {
+		Draw::DrawingContext context(canvas,
+		    layout,
+		    events.draw,
+		    *actPlot);
 
 		Draw::DrawBackground(
 		    layout.boundary.outline(Geom::Size::Square(1)),
@@ -147,7 +149,7 @@ void Chart::draw(Gfx::ICanvas &canvas) const
 
 	if (events.draw.logo->invoke()) {
 		auto filter = *(actPlot ? actPlot->getStyle()
-		                           : stylesheet.getDefaultParams())
+		                        : stylesheet.getDefaultParams())
 		                   .logo.filter;
 
 		auto logoRect = getLogoBoundary();
@@ -164,8 +166,8 @@ void Chart::draw(Gfx::ICanvas &canvas) const
 Geom::Rect Chart::getLogoBoundary() const
 {
 	const auto &logoStyle = (actPlot ? actPlot->getStyle()
-	                              : stylesheet.getDefaultParams())
-	                      .logo;
+	                                 : stylesheet.getDefaultParams())
+	                            .logo;
 
 	auto logoWidth =
 	    logoStyle.width->get(layout.boundary.size.minSize(),
@@ -178,12 +180,12 @@ Geom::Rect Chart::getLogoBoundary() const
 	        Styles::Sheet::baseFontSize(layout.boundary.size, false));
 
 	return {layout.boundary.topRight()
-	                      - Geom::Point(logoPad.right + logoWidth,
-	                          logoPad.bottom + logoHeight),
+	            - Geom::Point(logoPad.right + logoWidth,
+	                logoPad.bottom + logoHeight),
 	    Geom::Size(logoWidth, logoHeight)};
 }
 
-Gen::PlotPtr Chart::plot(const Gen::PlotOptionsPtr& options)
+Gen::PlotPtr Chart::plot(const Gen::PlotOptionsPtr &options)
 {
 	computedStyles =
 	    stylesheet.getFullParams(options, layout.boundary.size);
@@ -202,12 +204,13 @@ Draw::CoordinateSystem Chart::getCoordSystem() const
 
 		return {plotArea,
 		    options.angle,
-		    options.polar,
+		    options.coordSystem,
 		    actPlot->keepAspectRatio};
 	}
 	return {plotArea,
 	    0.0,
-	    Math::FuzzyBool(),
+	    ::Anim::Interpolated<Gen::CoordSystem>{
+	        Gen::CoordSystem::cartesian},
 	    Math::FuzzyBool()};
 }
 
@@ -219,19 +222,19 @@ Gen::Marker *Chart::markerAt(const Geom::Point &point) const
 
 		const Draw::CoordinateSystem coordSys(plotArea,
 		    options.angle,
-		    options.polar,
+		    options.coordSystem,
 		    actPlot->keepAspectRatio);
 
 		auto originalPos = coordSys.getOriginal(point);
 
 		for (auto &marker : actPlot->getMarkers()) {
-			auto drawItem = Draw::AbstractMarker::createInterpolated(
-			    marker,
-			    options,
-			    actPlot->getStyle(),
-			    coordSys,
-			    actPlot->getMarkers(),
-			    0);
+			auto drawItem =
+			    Draw::AbstractMarker::createInterpolated(marker,
+			        options,
+			        actPlot->getStyle(),
+			        coordSys,
+			        actPlot->getMarkers(),
+			        0);
 
 			if (drawItem.bounds(originalPos)) return &marker;
 		}

--- a/src/chart/main/events.h
+++ b/src/chart/main/events.h
@@ -4,9 +4,9 @@
 #include <optional>
 
 #include "base/anim/control.h"
+#include "base/conv/auto_json.h"
 #include "base/geom/line.h"
 #include "base/geom/rect.h"
-#include "base/conv/auto_json.h"
 #include "base/util/eventdispatcher.h"
 
 namespace Vizzu

--- a/src/chart/main/stylesheet.cpp
+++ b/src/chart/main/stylesheet.cpp
@@ -110,7 +110,7 @@ void Sheet::setMarkers()
 	}
 
 	if (options->getChannels().anyAxisSet()
-	    && options->shapeType == Gen::ShapeType::circle
+	    && options->geometry == Gen::ShapeType::circle
 	    && !options->getChannels()
 	            .at(Gen::ChannelId::size)
 	            .isDimension()
@@ -121,8 +121,7 @@ void Sheet::setMarkers()
 	}
 
 	if (options->getChannels().anyAxisSet()
-	    && options->shapeType
-	           == Gen::ShapeType::rectangle
+	    && options->geometry == Gen::ShapeType::rectangle
 	    && static_cast<bool>(options->polar)
 	    && options->getVeritalAxis().isEmpty()) {
 		defaultParams.plot.marker.rectangleSpacing = 0;
@@ -134,11 +133,9 @@ void Sheet::setMarkerLabels()
 	auto &def = defaultParams.plot.marker.label;
 
 	if (options->getChannels().anyAxisSet()
-	    && (!(options->shapeType
-	             == Gen::ShapeType::rectangle)
+	    && (!(options->geometry == Gen::ShapeType::rectangle)
 	         || options->subAxis().dimensionCount() == 0)) {
-		if (options->shapeType
-		    == Gen::ShapeType::circle) {
+		if (options->geometry == Gen::ShapeType::circle) {
 			def.position = MarkerLabel::Position::right;
 		}
 		else {
@@ -146,10 +143,8 @@ void Sheet::setMarkerLabels()
 			                 ? MarkerLabel::Position::top
 			                 : MarkerLabel::Position::right;
 
-			if (options->shapeType
-			        == Gen::ShapeType::area
-			    || options->shapeType
-			           == Gen::ShapeType::line) {
+			if (options->geometry == Gen::ShapeType::area
+			    || options->geometry == Gen::ShapeType::line) {
 				def.paddingBottom = Gfx::Length::Emphemeral(8 / 11.0);
 				def.paddingLeft = Gfx::Length::Emphemeral(8 / 11.0);
 				def.paddingTop = Gfx::Length::Emphemeral(8 / 11.0);

--- a/src/chart/main/stylesheet.cpp
+++ b/src/chart/main/stylesheet.cpp
@@ -56,7 +56,7 @@ double Sheet::baseFontSize(const Geom::Size &size, bool rounded)
 
 void Sheet::setPlot()
 {
-	if (static_cast<bool>(options->polar)) {
+	if (options->coordSystem.get() == Gen::CoordSystem::polar) {
 		defaultParams.plot.paddingLeft = 0;
 	}
 	else if (!options->getChannels().anyAxisSet()) {
@@ -81,7 +81,7 @@ void Sheet::setAxis()
 
 void Sheet::setAxisLabels()
 {
-	if (options->polar) {
+	if (options->coordSystem.get() == Gen::CoordSystem::polar) {
 		auto &def = defaultParams.plot.xAxis.label;
 		def.position = AxisLabel::Position::max_edge;
 		def.side = AxisLabel::Side::positive;
@@ -90,7 +90,7 @@ void Sheet::setAxisLabels()
 
 void Sheet::setAxisTitle()
 {
-	if (options->polar) {
+	if (options->coordSystem.get() == Gen::CoordSystem::polar) {
 		auto &def = defaultParams.plot.xAxis.title;
 		def.position = AxisTitle::Position::max_edge;
 		def.side = AxisTitle::Side::positive;
@@ -122,7 +122,7 @@ void Sheet::setMarkers()
 
 	if (options->getChannels().anyAxisSet()
 	    && options->geometry == Gen::ShapeType::rectangle
-	    && static_cast<bool>(options->polar)
+	    && options->coordSystem.get() == Gen::CoordSystem::polar
 	    && options->getVeritalAxis().isEmpty()) {
 		defaultParams.plot.marker.rectangleSpacing = 0;
 	}

--- a/src/chart/options/advancedoptions.cpp
+++ b/src/chart/options/advancedoptions.cpp
@@ -45,7 +45,7 @@ void OrientationSelector::fixHorizontal()
 std::optional<bool> OrientationSelector::horizontalOverride() const
 {
 	if (options.getChannels().anyAxisSet()
-	    && options.shapeType != ShapeType::circle) {
+	    && options.geometry != ShapeType::circle) {
 		auto &x = options.getChannels().at(ChannelId::x);
 		auto &y = options.getChannels().at(ChannelId::y);
 

--- a/src/chart/options/config.cpp
+++ b/src/chart/options/config.cpp
@@ -247,19 +247,7 @@ Config::Accessors Config::initAccessors()
 
 	res.emplace(accessor<&Options::title>);
 	res.emplace(accessor<&Options::legend>);
-
-	res.insert({"coordSystem",
-	    {.get =
-	            [](const Options &options)
-	        {
-		        return Conv::toString(options.coordSystem);
-	        },
-	        .set =
-	            [](OptionsSetter &setter, const std::string &value)
-	        {
-		        setter.setCoordSystem(
-		            Conv::parse<CoordSystem>(value));
-	        }}});
+	res.emplace(accessor<&Options::coordSystem>);
 
 	res.insert({"rotate",
 	    {.get =
@@ -292,18 +280,7 @@ Config::Accessors Config::initAccessors()
 		            orientation == Orientation::horizontal);
 	        }}});
 
-	res.insert({"sort",
-	    {.get =
-	            [](const Options &options)
-	        {
-		        return Conv::toString(options.sorted);
-	        },
-	        .set =
-	            [](OptionsSetter &setter, const std::string &value)
-	        {
-		        setter.setSorted(Conv::parse<Sort>(value));
-	        }}});
-
+	res.emplace(accessor<&Options::sort>);
 	res.emplace(accessor<&Options::reverse>);
 	res.emplace(accessor<&Options::align>);
 	res.emplace(accessor<&Options::split>);

--- a/src/chart/options/config.cpp
+++ b/src/chart/options/config.cpp
@@ -20,7 +20,7 @@ struct ExtractIf<::Anim::Interpolated<T>>
 {
 	using type = T;
 	constexpr const T &operator()(
-	    const ::Anim::Interpolated<T> &value) const noexcept
+	    const ::Anim::Interpolated<T> &value) const
 	{
 		return value.get();
 	}
@@ -31,7 +31,7 @@ struct ExtractIf<Math::FuzzyBool> {
 	using type = bool;
 
 	constexpr bool operator()(
-	    const Math::FuzzyBool &value) const noexcept
+	    const Math::FuzzyBool &value) const
 	{
 		return static_cast<bool>(value);
 	}

--- a/src/chart/options/config.cpp
+++ b/src/chart/options/config.cpp
@@ -92,8 +92,7 @@ void Config::setParam(const std::string &path,
 
 std::string Config::getParam(const std::string &path) const
 {
-	if (path.starts_with("channels."))
-		return getChannelParam(path);
+	if (path.starts_with("channels.")) return getChannelParam(path);
 
 	if (auto it = accessors.find(path); it != accessors.end())
 		return it->second.get(setter->getOptions());
@@ -192,9 +191,7 @@ std::string Config::getChannelParam(const std::string &path) const
 	if (property == "labels") {
 		return Conv::toString(channel.axisLabels);
 	}
-	if (property == "ticks") {
-		return Conv::toString(channel.ticks);
-	}
+	if (property == "ticks") { return Conv::toString(channel.ticks); }
 	if (property == "interlacing") {
 		return Conv::toString(channel.interlacing);
 	}
@@ -255,15 +252,13 @@ Config::Accessors Config::initAccessors()
 	    {.get =
 	            [](const Options &options)
 	        {
-		        auto cs{options.polar ? CoordSystem::polar
-		                              : CoordSystem::cartesian};
-		        return Conv::toString(cs);
+		        return Conv::toString(options.coordSystem);
 	        },
 	        .set =
 	            [](OptionsSetter &setter, const std::string &value)
 	        {
-		        auto coordSys = Conv::parse<CoordSystem>(value);
-		        setter.setPolar(coordSys == CoordSystem::polar);
+		        setter.setCoordSystem(
+		            Conv::parse<CoordSystem>(value));
 	        }}});
 
 	res.insert({"rotate",
@@ -301,14 +296,12 @@ Config::Accessors Config::initAccessors()
 	    {.get =
 	            [](const Options &options)
 	        {
-		        auto res(options.sorted ? Sort::byValue : Sort::none);
-		        return Conv::toString(res);
+		        return Conv::toString(options.sorted);
 	        },
 	        .set =
 	            [](OptionsSetter &setter, const std::string &value)
 	        {
-		        auto sort = Conv::parse<Sort>(value);
-		        setter.setSorted(sort == Sort::byValue);
+		        setter.setSorted(Conv::parse<Sort>(value));
 	        }}});
 
 	res.emplace(accessor<&Options::reverse>);

--- a/src/chart/options/config.h
+++ b/src/chart/options/config.h
@@ -15,10 +15,6 @@ namespace Vizzu::Gen
 class Config
 {
 public:
-	enum class CoordSystem { cartesian, polar };
-	enum class Orientation { horizontal, vertical };
-	enum class Sort { none, byValue };
-
 	static std::list<std::string> listParams();
 	[[nodiscard]] std::string getParam(const std::string &path) const;
 	void setParam(const std::string &path, const std::string &value);

--- a/src/chart/options/config.h
+++ b/src/chart/options/config.h
@@ -28,11 +28,14 @@ public:
 private:
 	struct Accessor
 	{
-		std::function<std::string(const Options &)> get;
-		std::function<void(OptionsSetter &, const std::string &)> set;
+		std::string (*get)(const Options &);
+		void (*set)(OptionsSetter &, const std::string &);
 	};
 
-	using Accessors = std::map<std::string, Accessor>;
+	template <auto Mptr, class>
+	static const std::pair<std::string_view, Config::Accessor> accessor;
+
+	using Accessors = std::map<std::string_view, Accessor>;
 
 	const static Accessors accessors;
 	OptionsSetterPtr setter;

--- a/src/chart/options/config.h
+++ b/src/chart/options/config.h
@@ -28,7 +28,7 @@ private:
 		void (*set)(OptionsSetter &, const std::string &);
 	};
 
-	template <auto Mptr, class>
+	template <auto Mptr, auto Set, class>
 	static const std::pair<std::string_view, Config::Accessor> accessor;
 
 	using Accessors = std::map<std::string_view, Accessor>;

--- a/src/chart/options/coordsystem.h
+++ b/src/chart/options/coordsystem.h
@@ -1,0 +1,11 @@
+#ifndef CHART_OPTIONS_COORDSYSTEM_H
+#define CHART_OPTIONS_COORDSYSTEM_H
+
+namespace Vizzu::Gen
+{
+
+enum class CoordSystem { cartesian, polar };
+
+}
+
+#endif

--- a/src/chart/options/options.cpp
+++ b/src/chart/options/options.cpp
@@ -17,15 +17,6 @@ ChannelExtrema operator"" _perc(long double percent)
 
 uint64_t Options::nextMarkerInfoId = 1;
 
-Options::Options() :
-    title(std::nullopt),
-    coordSystem(CoordSystem::cartesian),
-    geometry(ShapeType::rectangle),
-    horizontal(true),
-    sorted(Sort::none),
-    reverse(false)
-{}
-
 void Options::reset()
 {
 	channels.reset();
@@ -185,7 +176,7 @@ bool Options::sameShadowAttribs(const Options &other) const
 	return shape == shapeOther && coordSystem == other.coordSystem
 	    && angle == other.angle && horizontal == other.horizontal
 	    && split == other.split && dataFilter == other.dataFilter
-	    && align == other.align && sorted == other.sorted
+	    && align == other.align && sort == other.sort
 	    && reverse == other.reverse;
 }
 

--- a/src/chart/options/options.cpp
+++ b/src/chart/options/options.cpp
@@ -19,10 +19,10 @@ uint64_t Options::nextMarkerInfoId = 1;
 
 Options::Options() :
     title(std::nullopt),
-    polar(false),
+    coordSystem(CoordSystem::cartesian),
     geometry(ShapeType::rectangle),
     horizontal(true),
-    sorted(false),
+    sorted(Sort::none),
     reverse(false)
 {}
 
@@ -182,7 +182,7 @@ bool Options::sameShadowAttribs(const Options &other) const
 	auto shapeOther = other.geometry;
 	if (shapeOther == ShapeType::line) shapeOther = ShapeType::area;
 
-	return shape == shapeOther && polar == other.polar
+	return shape == shapeOther && coordSystem == other.coordSystem
 	    && angle == other.angle && horizontal == other.horizontal
 	    && split == other.split && dataFilter == other.dataFilter
 	    && align == other.align && sorted == other.sorted
@@ -276,7 +276,7 @@ void Options::setAutoRange(bool hPositive, bool vPositive)
 		setRange(h, 0.0_perc, 100.0_perc);
 		setRange(v, 0.0_perc, 100.0_perc);
 	}
-	else if (!static_cast<bool>(polar)) {
+	else if (coordSystem.get() != CoordSystem::polar) {
 		if (!h.isDimension() && !v.isDimension()
 		    && geometry == ShapeType::rectangle) {
 			setRange(h, 0.0_perc, 100.0_perc);

--- a/src/chart/options/options.cpp
+++ b/src/chart/options/options.cpp
@@ -20,7 +20,7 @@ uint64_t Options::nextMarkerInfoId = 1;
 Options::Options() :
     title(std::nullopt),
     polar(false),
-    shapeType(ShapeType::rectangle),
+    geometry(ShapeType::rectangle),
     horizontal(true),
     sorted(false),
     reverse(false)
@@ -35,7 +35,7 @@ void Options::reset()
 
 const Channel *Options::subAxisOf(ChannelId id) const
 {
-	switch (shapeType.get()) {
+	switch (geometry.get()) {
 	case ShapeType::rectangle:
 		return id == mainAxisType() ? &subAxis() : nullptr;
 
@@ -68,7 +68,7 @@ const Channel *Options::subAxisOf(ChannelId id) const
 ChannelId Options::stackAxisType() const
 {
 	if (channels.anyAxisSet()) {
-		switch (shapeType.get()) {
+		switch (geometry.get()) {
 		case ShapeType::area:
 		case ShapeType::rectangle: return subAxisType();
 		default:
@@ -82,7 +82,7 @@ ChannelId Options::stackAxisType() const
 
 std::optional<ChannelId> Options::secondaryStackType() const
 {
-	if (channels.anyAxisSet() && shapeType == ShapeType::line)
+	if (channels.anyAxisSet() && geometry == ShapeType::line)
 		return subAxisType();
 
 	return std::nullopt;
@@ -176,23 +176,22 @@ bool Options::sameShadow(const Options &other) const
 
 bool Options::sameShadowAttribs(const Options &other) const
 {
-	auto shape = shapeType;
+	auto shape = geometry;
 	if (shape == ShapeType::line) shape = ShapeType::area;
 
-	auto shapeOther = other.shapeType;
+	auto shapeOther = other.geometry;
 	if (shapeOther == ShapeType::line) shapeOther = ShapeType::area;
 
 	return shape == shapeOther && polar == other.polar
 	    && angle == other.angle && horizontal == other.horizontal
-	    && splitted == other.splitted
-	    && dataFilter == other.dataFilter
-	    && alignType == other.alignType && splitted == other.splitted
-	    && sorted == other.sorted && reverse == other.reverse;
+	    && split == other.split && dataFilter == other.dataFilter
+	    && align == other.align && sorted == other.sorted
+	    && reverse == other.reverse;
 }
 
 bool Options::sameAttributes(const Options &other) const
 {
-	return sameShadowAttribs(other) && shapeType == other.shapeType
+	return sameShadowAttribs(other) && geometry == other.geometry
 	    && title == other.title && legend == other.legend
 	    && markersInfo == other.markersInfo;
 }
@@ -279,7 +278,7 @@ void Options::setAutoRange(bool hPositive, bool vPositive)
 	}
 	else if (!static_cast<bool>(polar)) {
 		if (!h.isDimension() && !v.isDimension()
-		    && shapeType == ShapeType::rectangle) {
+		    && geometry == ShapeType::rectangle) {
 			setRange(h, 0.0_perc, 100.0_perc);
 			setRange(v, 0.0_perc, 100.0_perc);
 		}

--- a/src/chart/options/options.h
+++ b/src/chart/options/options.h
@@ -19,6 +19,9 @@
 #include "autoparam.h"
 #include "channels.h"
 #include "shapetype.h"
+#include "coordsystem.h"
+#include "orientation.h"
+#include "sort.h"
 
 namespace Vizzu::Gen
 {
@@ -73,14 +76,14 @@ public:
 	Channel &stackAxis() { return channels.at(stackAxisType()); }
 
 	Title title;
-	Math::FuzzyBool polar;
+	Anim::Interpolated<CoordSystem> coordSystem;
 	double angle;
 	Anim::Interpolated<ShapeType> geometry;
 	Math::FuzzyBool horizontal;
 	Math::FuzzyBool split;
 	Base::Align::Type align{Base::Align::Type::none};
 	Data::Filter dataFilter;
-	Math::FuzzyBool sorted;
+	Sort sorted;
 	Math::FuzzyBool reverse;
 	Legend legend;
 	std::optional<uint64_t> tooltip;

--- a/src/chart/options/options.h
+++ b/src/chart/options/options.h
@@ -35,7 +35,7 @@ public:
 	using Legend = ::Anim::Interpolated<LegendType>;
 	using MarkersInfoMap = std::map<uint64_t, MarkerId>;
 
-	Options();
+	Options() = default;
 
 	[[nodiscard]] const Channels &getChannels() const
 	{
@@ -75,16 +75,16 @@ public:
 
 	Channel &stackAxis() { return channels.at(stackAxisType()); }
 
-	Title title;
-	Anim::Interpolated<CoordSystem> coordSystem;
+	Title title{std::nullopt};
+	Anim::Interpolated<CoordSystem> coordSystem{CoordSystem::cartesian};
 	double angle;
-	Anim::Interpolated<ShapeType> geometry;
-	Math::FuzzyBool horizontal;
+	Anim::Interpolated<ShapeType> geometry{ShapeType::rectangle};
+	Math::FuzzyBool horizontal{true};
 	Math::FuzzyBool split;
 	Base::Align::Type align{Base::Align::Type::none};
 	Data::Filter dataFilter;
-	Sort sorted;
-	Math::FuzzyBool reverse;
+	Sort sort{Sort::none};
+	Math::FuzzyBool reverse{false};
 	Legend legend;
 	std::optional<uint64_t> tooltip;
 	MarkersInfoMap markersInfo;

--- a/src/chart/options/options.h
+++ b/src/chart/options/options.h
@@ -28,7 +28,8 @@ class Options
 public:
 	using MarkerId = uint64_t;
 	using Title = ::Anim::Interpolated<std::optional<std::string>>;
-	using Legend = ::Anim::Interpolated<Base::AutoParam<ChannelId>>;
+	using LegendType = Base::AutoParam<ChannelId>;
+	using Legend = ::Anim::Interpolated<LegendType>;
 	using MarkersInfoMap = std::map<uint64_t, MarkerId>;
 
 	Options();
@@ -74,15 +75,15 @@ public:
 	Title title;
 	Math::FuzzyBool polar;
 	double angle;
-	Anim::Interpolated<ShapeType> shapeType;
+	Anim::Interpolated<ShapeType> geometry;
 	Math::FuzzyBool horizontal;
-	Math::FuzzyBool splitted;
-	Base::Align::Type alignType{Base::Align::Type::none};
+	Math::FuzzyBool split;
+	Base::Align::Type align{Base::Align::Type::none};
 	Data::Filter dataFilter;
 	Math::FuzzyBool sorted;
 	Math::FuzzyBool reverse;
 	Legend legend;
-	std::optional<uint64_t> tooltipId;
+	std::optional<uint64_t> tooltip;
 	MarkersInfoMap markersInfo;
 
 	bool operator==(const Options &other) const;

--- a/src/chart/options/options.h
+++ b/src/chart/options/options.h
@@ -18,9 +18,9 @@
 #include "align.h"
 #include "autoparam.h"
 #include "channels.h"
-#include "shapetype.h"
 #include "coordsystem.h"
 #include "orientation.h"
+#include "shapetype.h"
 #include "sort.h"
 
 namespace Vizzu::Gen
@@ -76,7 +76,8 @@ public:
 	Channel &stackAxis() { return channels.at(stackAxisType()); }
 
 	Title title{std::nullopt};
-	Anim::Interpolated<CoordSystem> coordSystem{CoordSystem::cartesian};
+	Anim::Interpolated<CoordSystem> coordSystem{
+	    CoordSystem::cartesian};
 	double angle;
 	Anim::Interpolated<ShapeType> geometry{ShapeType::rectangle};
 	Math::FuzzyBool horizontal{true};

--- a/src/chart/options/optionssetter.cpp
+++ b/src/chart/options/optionssetter.cpp
@@ -130,7 +130,7 @@ OptionsSetter::setLabelLevel(const ChannelId &channelId, int level)
 
 OptionsSetter &OptionsSetter::setSorted(Sort value)
 {
-	options.sorted = value;
+	options.sort = value;
 	return *this;
 }
 

--- a/src/chart/options/optionssetter.cpp
+++ b/src/chart/options/optionssetter.cpp
@@ -74,14 +74,14 @@ OptionsSetter &OptionsSetter::clearSeries(const ChannelId &channelId)
 
 OptionsSetter &OptionsSetter::setShape(const ShapeType &type)
 {
-	options.shapeType = type;
+	options.geometry = type;
 	return *this;
 }
 
 OptionsSetter &OptionsSetter::setAlign(
     const Base::Align::Type &alignType)
 {
-	options.alignType = alignType;
+	options.align = alignType;
 	return *this;
 }
 
@@ -93,7 +93,7 @@ OptionsSetter &OptionsSetter::setPolar(bool value)
 
 OptionsSetter &OptionsSetter::setSplitted(bool value)
 {
-	options.splitted = Math::FuzzyBool(value);
+	options.split = Math::FuzzyBool(value);
 	return *this;
 }
 
@@ -168,13 +168,14 @@ OptionsSetter &OptionsSetter::setTitle(
 	return *this;
 }
 
-OptionsSetter &OptionsSetter::setLegend(const Options::Legend &legend)
+OptionsSetter &OptionsSetter::setLegend(
+    const Options::LegendType &legend)
 {
 	options.legend = legend;
 	return *this;
 }
 
-OptionsSetter &OptionsSetter::setTitle(const ChannelId &channelId,
+OptionsSetter &OptionsSetter::setAxisTitle(const ChannelId &channelId,
     const std::string &title)
 {
 	options.getChannels().at(channelId).title = title;
@@ -270,19 +271,19 @@ OptionsSetter &OptionsSetter::deleteMarkerInfo(
 OptionsSetter &OptionsSetter::showTooltip(
     std::optional<Options::MarkerId> marker)
 {
-	auto current = options.tooltipId;
+	auto current = options.tooltip;
 	if (!marker.has_value() && current.has_value()) {
 		deleteMarkerInfo(*current);
-		options.tooltipId.reset();
+		options.tooltip.reset();
 	}
 	else if (marker.has_value() && !current.has_value()) {
 		addMarkerInfo(*marker);
-		options.tooltipId = marker;
+		options.tooltip = marker;
 	}
 	else if (marker.has_value() && current.has_value()
 	         && marker != current) {
 		moveMarkerInfo(*current, *marker);
-		options.tooltipId = marker;
+		options.tooltip = marker;
 	}
 	return *this;
 }

--- a/src/chart/options/optionssetter.cpp
+++ b/src/chart/options/optionssetter.cpp
@@ -85,9 +85,9 @@ OptionsSetter &OptionsSetter::setAlign(
 	return *this;
 }
 
-OptionsSetter &OptionsSetter::setPolar(bool value)
+OptionsSetter &OptionsSetter::setCoordSystem(CoordSystem coordSystem)
 {
-	options.polar = Math::FuzzyBool(value);
+	options.coordSystem = coordSystem;
 	return *this;
 }
 
@@ -128,7 +128,7 @@ OptionsSetter::setLabelLevel(const ChannelId &channelId, int level)
 	return *this;
 }
 
-OptionsSetter &OptionsSetter::setSorted(bool value)
+OptionsSetter &OptionsSetter::setSorted(Sort value)
 {
 	options.sorted = value;
 	return *this;

--- a/src/chart/options/optionssetter.h
+++ b/src/chart/options/optionssetter.h
@@ -58,8 +58,9 @@ public:
 	    bool value);
 	virtual OptionsSetter &setTitle(
 	    const std::optional<std::string> &title);
-	virtual OptionsSetter &setLegend(const Options::Legend &legend);
-	virtual OptionsSetter &setTitle(const ChannelId &channelId,
+	virtual OptionsSetter &setLegend(
+	    const Options::LegendType &legend);
+	virtual OptionsSetter &setAxisTitle(const ChannelId &channelId,
 	    const std::string &title);
 	virtual OptionsSetter &setAxisLine(const ChannelId &channelId,
 	    Base::AutoBool enable);

--- a/src/chart/options/optionssetter.h
+++ b/src/chart/options/optionssetter.h
@@ -40,7 +40,7 @@ public:
 	virtual OptionsSetter &setShape(const ShapeType &type);
 	virtual OptionsSetter &setAlign(
 	    const Base::Align::Type &alignType);
-	virtual OptionsSetter &setPolar(bool value);
+	virtual OptionsSetter &setCoordSystem(CoordSystem coordSystem);
 	virtual OptionsSetter &setSplitted(bool value);
 	virtual OptionsSetter &rotate(double ccwQuadrant);
 	virtual OptionsSetter &setAngle(double ccwQuadrant);
@@ -48,7 +48,7 @@ public:
 	virtual OptionsSetter &setFilter(const Data::Filter &filter);
 	virtual OptionsSetter &setLabelLevel(const ChannelId &channelId,
 	    int level);
-	virtual OptionsSetter &setSorted(bool value);
+	virtual OptionsSetter &setSorted(Sort value);
 	virtual OptionsSetter &setReverse(bool value);
 	virtual OptionsSetter &setRangeMin(const ChannelId &channelId,
 	    const OptionalChannelExtrema &value);

--- a/src/chart/options/orientation.h
+++ b/src/chart/options/orientation.h
@@ -1,0 +1,11 @@
+#ifndef CHART_OPTIONS_ORIENTATION_H
+#define CHART_OPTIONS_ORIENTATION_H
+
+namespace Vizzu::Gen
+{
+
+enum class Orientation { horizontal, vertical };
+
+}
+
+#endif

--- a/src/chart/options/shapetype.cpp
+++ b/src/chart/options/shapetype.cpp
@@ -1,6 +1,8 @@
 
 #include "shapetype.h"
 
+#include <stdexcept>
+
 using namespace Vizzu;
 using namespace Vizzu::Gen;
 

--- a/src/chart/options/shapetype.h
+++ b/src/chart/options/shapetype.h
@@ -1,10 +1,7 @@
 #ifndef SHAPETYPE_H
 #define SHAPETYPE_H
 
-#include <array>
-#include <string>
-
-#include "base/math/fuzzybool.h"
+#include <cstdint>
 
 namespace Vizzu::Gen
 {

--- a/src/chart/options/sort.h
+++ b/src/chart/options/sort.h
@@ -1,0 +1,11 @@
+#ifndef CHART_OPTIONS_SORT_H
+#define CHART_OPTIONS_SORT_H
+
+namespace Vizzu::Gen
+{
+
+enum class Sort { none, byValue };
+
+}
+
+#endif

--- a/src/chart/rendering/drawingcontext.h
+++ b/src/chart/rendering/drawingcontext.h
@@ -34,7 +34,7 @@ public:
 		coordSys = CoordinateSystem(
 		    plotArea,
 		    options.angle,
-		    options.polar,
+		    options.coordSystem,
 		    plot.keepAspectRatio
 		);
 

--- a/src/chart/rendering/drawmarkerinfo.cpp
+++ b/src/chart/rendering/drawmarkerinfo.cpp
@@ -204,7 +204,7 @@ DrawMarkerInfo::DrawMarkerInfo(const Layout &layout,
 {
 	auto coordSys = Draw::CoordinateSystem(layout.plotArea,
 	    plot.getOptions()->angle,
-	    plot.getOptions()->polar,
+	    plot.getOptions()->coordSystem,
 	    plot.keepAspectRatio);
 	coordSystem = &coordSys;
 	for (const auto &info : plot.getMarkersInfo()) {

--- a/src/chart/rendering/markerrenderer.cpp
+++ b/src/chart/rendering/markerrenderer.cpp
@@ -75,8 +75,8 @@ void MarkerRenderer::draw()
 {
 	if (!shouldDrawMarkerBody()) return;
 
-	if (options.shapeType.contains(Gen::ShapeType::line)
-	    && options.shapeType.contains(Gen::ShapeType::circle)) {
+	if (options.geometry.contains(Gen::ShapeType::line)
+	    && options.geometry.contains(Gen::ShapeType::circle)) {
 		const CircleMarker circle(marker,
 		    coordSys,
 		    options,
@@ -109,7 +109,7 @@ void MarkerRenderer::draw()
 			    plot.getMarkers(),
 			    index);
 
-			auto lineFactor = options.shapeType.factor<double>(
+			auto lineFactor = options.geometry.factor<double>(
 			    Gen::ShapeType::line);
 
 			draw(blended0,
@@ -119,17 +119,17 @@ void MarkerRenderer::draw()
 		};
 
 		auto containsConnected =
-		    options.shapeType.contains(Gen::ShapeType::line)
-		    || options.shapeType.contains(Gen::ShapeType::area);
+		    options.geometry.contains(Gen::ShapeType::line)
+		    || options.geometry.contains(Gen::ShapeType::area);
 
 		auto containsSingle =
-		    options.shapeType.contains(Gen::ShapeType::rectangle)
-		    || options.shapeType.contains(Gen::ShapeType::circle);
+		    options.geometry.contains(Gen::ShapeType::rectangle)
+		    || options.geometry.contains(Gen::ShapeType::circle);
 
 		if (containsConnected) {
 			if (containsSingle) {
 				auto lineIndex =
-				    Gen::isConnecting(options.shapeType.get(0).value)
+				    Gen::isConnecting(options.geometry.get(0).value)
 				        ? 0
 				        : 1;
 
@@ -161,7 +161,7 @@ void MarkerRenderer::drawLabel()
 bool MarkerRenderer::shouldDrawMarkerBody()
 {
 	bool enabled = static_cast<double>(marker.enabled) > 0;
-	if (options.shapeType.factor<Math::FuzzyBool>(
+	if (options.geometry.factor<Math::FuzzyBool>(
 	        Gen::ShapeType::area)
 	    != false) {
 		const auto *prev0 =

--- a/src/chart/rendering/markerrenderer.cpp
+++ b/src/chart/rendering/markerrenderer.cpp
@@ -54,7 +54,8 @@ void MarkerRenderer::drawLines(const Styles::Guide &style,
 		if (static_cast<double>(plot.guides.y.guidelines) > 0) {
 			blended.center.x = Math::interpolate(blended.center.x,
 			    1.0,
-			    static_cast<double>(options.polar));
+			    options.coordSystem.factor<double>(
+			        Gen::CoordSystem::polar));
 			auto lineColor =
 			    baseColor
 			    * static_cast<double>(plot.guides.y.guidelines);

--- a/src/chart/rendering/markers/abstractmarker.cpp
+++ b/src/chart/rendering/markers/abstractmarker.cpp
@@ -39,12 +39,12 @@ AbstractMarker AbstractMarker::createInterpolated(const Gen::Marker &marker,
     const Gen::Plot::Markers &markers,
     size_t lineIndex) 
 {
-	auto fromShapeType = options.shapeType.get(0).value;
+	auto fromShapeType = options.geometry.get(0).value;
 
 	auto fromMarker = create(marker, options, fromShapeType, style,
 		coordSys, markers, lineIndex);
 
-	auto toShapeType = options.shapeType.get(1).value;
+	auto toShapeType = options.geometry.get(1).value;
 
 	if (fromShapeType == toShapeType) return fromMarker;
 
@@ -186,7 +186,7 @@ AbstractMarker::AbstractMarker(const Gen::Marker &marker,
     const Gen::Options &options) : 
     marker(marker),
     coordSys(coordSys),
-    shapeType(options.shapeType),
+    shapeType(options.geometry),
     enabled(false), 
     labelEnabled(false)
 {
@@ -200,7 +200,7 @@ SingleDrawMarker::SingleDrawMarker(const Gen::Marker &marker,
     AbstractMarker(marker, coordSys, options)
 {
 	enabled =
-	    options.shapeType.factor<Math::FuzzyBool>(type) && marker.enabled;
+	    options.geometry.factor<Math::FuzzyBool>(type) && marker.enabled;
 
 	labelEnabled = enabled;
 }

--- a/src/chart/rendering/markers/connectingmarker.cpp
+++ b/src/chart/rendering/markers/connectingmarker.cpp
@@ -17,7 +17,10 @@ ConnectingMarker::ConnectingMarker(const Gen::Marker &marker,
 	auto isLine = type == Gen::ShapeType::line;
 	auto isArea = type == Gen::ShapeType::area;
 
-	linear = !options.polar || options.horizontal;
+	auto polar = options.coordSystem.factor<Math::FuzzyBool>(
+	    Gen::CoordSystem::polar);
+
+	linear = !polar || options.horizontal;
 
 	lineWidth[0] = lineWidth[1] = 0;
 
@@ -39,9 +42,9 @@ ConnectingMarker::ConnectingMarker(const Gen::Marker &marker,
 			if (prev->mainId.get(lineIndex).value.itemId 
 				> marker.mainId.get(lineIndex).value.itemId) 
 			{
-				linear = linear || options.polar.more();
-				connected = connected && options.polar.more() && options.horizontal;
-				enabled = enabled && options.polar && options.horizontal;
+				linear = linear || polar.more();
+				connected = connected && polar.more() && options.horizontal;
+				enabled = enabled && polar && options.horizontal;
 			}
 			if (isArea) enabled = enabled && connected;
 		}
@@ -78,7 +81,7 @@ ConnectingMarker::ConnectingMarker(const Gen::Marker &marker,
 			auto prevSpacing = prev->spacing * prev->size / 2;
 			auto prevPos = prev->position;
 
-			if (options.polar != false) {
+			if (polar != false) {
 				if (options.horizontal.more() != false) {
 					if (prevPos.x >= 1) prevPos.x -= 1;
 				}

--- a/src/chart/rendering/markers/connectingmarker.cpp
+++ b/src/chart/rendering/markers/connectingmarker.cpp
@@ -21,7 +21,7 @@ ConnectingMarker::ConnectingMarker(const Gen::Marker &marker,
 
 	lineWidth[0] = lineWidth[1] = 0;
 
-	enabled = options.shapeType.factor<Math::FuzzyBool>(type);
+	enabled = options.geometry.factor<Math::FuzzyBool>(type);
 
 	labelEnabled = enabled && marker.enabled;
 

--- a/src/chart/rendering/markers/rectanglemarker.cpp
+++ b/src/chart/rendering/markers/rectanglemarker.cpp
@@ -12,7 +12,8 @@ RectangleMarker::RectangleMarker(const Gen::Marker &marker,
         options,
         Gen::ShapeType::rectangle)
 {
-	linear = static_cast<double>(options.polar) == 0;
+	linear = options.coordSystem.factor<double>(
+	             Gen::CoordSystem::polar) == 0;
 	border = Math::FuzzyBool(true);
 
 	const Geom::Size spacing =

--- a/src/chart/rendering/painter/coordinatesystem.cpp
+++ b/src/chart/rendering/painter/coordinatesystem.cpp
@@ -9,8 +9,8 @@ using namespace Vizzu::Draw;
 using namespace Geom;
 
 PolarDescartesTransform::PolarDescartesTransform(
-    Math::FuzzyBool polar) :
-    polar(polar)
+    Anim::Interpolated<Gen::CoordSystem> coordSystem) :
+    polar(coordSystem.factor<double>(Gen::CoordSystem::polar))
 {
 	zoomOut = true;
 }
@@ -106,9 +106,9 @@ Size PolarDescartesTransform::mappedSize() const
 
 CompoundTransform::CompoundTransform(Rect rect,
     double angle,
-    Math::FuzzyBool polar,
+    Anim::Interpolated<Gen::CoordSystem> coordSystem,
     Math::FuzzyBool keepAspectRatio) :
-    PolarDescartesTransform(polar),
+    PolarDescartesTransform(coordSystem),
     rect(rect),
     keepAspectRatio(keepAspectRatio)
 {

--- a/src/chart/rendering/painter/coordinatesystem.h
+++ b/src/chart/rendering/painter/coordinatesystem.h
@@ -1,8 +1,10 @@
 #ifndef COORDINATESYSTEM_H
 #define COORDINATESYSTEM_H
 
+#include "base/anim/interpolated.h"
 #include "base/geom/rect.h"
 #include "base/math/fuzzybool.h"
+#include "chart/options/coordsystem.h"
 
 namespace Vizzu::Draw
 {
@@ -11,7 +13,8 @@ class PolarDescartesTransform
 {
 public:
 	PolarDescartesTransform() = default;
-	PolarDescartesTransform(Math::FuzzyBool polar);
+	PolarDescartesTransform(
+	    ::Anim::Interpolated<Gen::CoordSystem>coordSystem);
 	[[nodiscard]] Geom::Point convert(const Geom::Point &p) const;
 	[[nodiscard]] double horConvert(double length) const;
 	[[nodiscard]] double verConvert(double length) const;
@@ -32,7 +35,7 @@ public:
 	CompoundTransform() = default;
 	CompoundTransform(Geom::Rect rect,
 	    double angle,
-	    Math::FuzzyBool polar,
+	    ::Anim::Interpolated<Gen::CoordSystem> coordSystem,
 	    Math::FuzzyBool keepAspectRatio);
 	[[nodiscard]] Geom::Point convert(const Geom::Point &p) const;
 	[[nodiscard]] double horConvert(double length) const;

--- a/src/chart/speclayout/speclayout.cpp
+++ b/src/chart/speclayout/speclayout.cpp
@@ -17,8 +17,8 @@ bool SpecLayout::addIfNeeded()
 
 	if (options->getChannels().anyAxisSet()) return false;
 
-	if (options->shapeType == ShapeType::line
-	    || options->shapeType == ShapeType::area) {
+	if (options->geometry == ShapeType::line
+	    || options->geometry == ShapeType::area) {
 		TableChart::setupVector(markers, true);
 	}
 	else if (options->getChannels().at(ChannelId::size).isEmpty()) {
@@ -31,14 +31,14 @@ bool SpecLayout::addIfNeeded()
 			hierarchy[marker.sizeId.seriesId][marker.sizeId.itemId] =
 			    i;
 		}
-		if (options->shapeType == ShapeType::circle) {
+		if (options->geometry == ShapeType::circle) {
 			BubbleChartBuilder::setupVector(markers,
 			    *style.plot.marker.circleMaxRadius,
 			    hierarchy);
 
 			plot.keepAspectRatio = true;
 		}
-		else if (options->shapeType == ShapeType::rectangle) {
+		else if (options->geometry == ShapeType::rectangle) {
 			TreeMap::setupVector(markers, hierarchy);
 		}
 		else

--- a/test/qtest/chart.cpp
+++ b/test/qtest/chart.cpp
@@ -114,7 +114,7 @@ void TestChart::run()
 		setter->setFilter(Data::Filter());
 		setter->addSeries(ChannelId::y, "Cat2");
 		setter->addSeries(ChannelId::color, "Cat2");
-		setter->setPolar(true);
+		setter->setCoordSystem(CoordSystem::polar);
 		setter->setTitle("VIZZU Chart - Phase 2");
 		chart.getChart().getStyles().title.fontSize = 10;
 		chart.getChart().getStyles().legend.marker.type =


### PR DESCRIPTION
Separate enums from Config (CoordSystem, Sort, Orientation).

Rename options:
- polar (`FuzzyBool`) -> coordSystem (`Interpolated<CoordSystem>`)
- sorted (`FuzzyBool`) -> sort (`Sort`)
- shapeType-> geometry
- splitted -> split
- alignType -> align
- tooltipId -> tooltip

Use unified option access template, and get name from member automatically.


It decrease the binary size from
```
"wasm_make": 343169 : /workspace/build/cmake-wasm/weblib/cvizzu.wasm
"wasm_make": 150804 : /workspace/build/cmake-wasm/weblib/cvizzu.wasm.gz
```
to
```
"wasm_make": 341804 : /workspace/build/cmake-wasm/weblib/cvizzu.wasm
"wasm_make": 150167 : /workspace/build/cmake-wasm/weblib/cvizzu.wasm.gz
```
with ~1,3 kb