### PR TITLE
Not split blindly on (

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   cause multi-step animations.
 - Animation between two version of the same chart is instant only if duration
   is not explicitly set
+- Aggregators didn't work when there are parentheses in the name of the data 
+  series
+- Layout stretched to the bottom of the canvas. 
 
 ### Added
 

--- a/src/base/text/funcstring.cpp
+++ b/src/base/text/funcstring.cpp
@@ -26,7 +26,7 @@ FuncString::FuncString(std::string code, bool throwOnError)
 	parts[1].remove_suffix(1);
 
 	name = parts[0];
-	params.emplace_back(parts[1]);
+	if (!parts[1].empty()) params.emplace_back(parts[1]);
 
 	SmartString::trim(name);
 

--- a/src/base/text/funcstring.cpp
+++ b/src/base/text/funcstring.cpp
@@ -11,10 +11,10 @@ FuncString::FuncString(std::string code, bool throwOnError)
 
 	if (code.empty()) return;
 
-	std::array<std::string_view, 2> parts{};
+	std::array<std::string, 2> parts{};
 	if (auto where = code.find('('); where != std::string::npos) {
-		parts[0] = std::string_view{code}.substr(0, where);
-		parts[1] = std::string_view{code}.substr(where + 1);
+		parts[0] = code.substr(0, where);
+		parts[1] = code.substr(where + 1);
 	}
 
 	if (parts[1].empty() || parts[1].back() != ')') {
@@ -23,10 +23,10 @@ FuncString::FuncString(std::string code, bool throwOnError)
 		throw std::logic_error("invalid function format");
 	}
 
-	parts[1].remove_suffix(1);
+	parts[1].pop_back();
 
 	name = parts[0];
-	if (!parts[1].empty()) params.emplace_back(parts[1]);
+	params = SmartString::split(parts[1], ',');
 
 	SmartString::trim(name);
 

--- a/src/base/text/funcstring.cpp
+++ b/src/base/text/funcstring.cpp
@@ -11,19 +11,22 @@ FuncString::FuncString(std::string code, bool throwOnError)
 
 	if (code.empty()) return;
 
-	auto parts = SmartString::split(code, '(');
+	std::array<std::string_view, 2> parts{};
+	if (auto where = code.find('('); where != std::string::npos) {
+		parts[0] = std::string_view{code}.substr(0, where);
+		parts[1] = std::string_view{code}.substr(where + 1);
+	}
 
-	if (parts.size() != 2 || parts[1].empty()
-	    || parts[1].back() != ')') {
+	if (parts[1].empty() || parts[1].back() != ')') {
 		if (!throwOnError) return;
 
 		throw std::logic_error("invalid function format");
 	}
 
-	parts[1].pop_back();
+	parts[1].remove_suffix(1);
 
 	name = parts[0];
-	params = SmartString::split(parts[1], ',');
+	params.emplace_back(parts[1]);
 
 	SmartString::trim(name);
 

--- a/test/unit/base/text/funcstring.cpp
+++ b/test/unit/base/text/funcstring.cpp
@@ -23,29 +23,40 @@ const static auto tests =
 	            const FuncString f("   ");
 	            check() << f.isEmpty() == true;
             })
+        /*
+                .add_case("function_with_multiple_parameter_parsed",
+                    []
+                    {
+                        const FuncString f("foo(bar,baz)");
+                        check() << f.isEmpty() == false;
+                        check() << f.getName() == "foo";
+                        check() << f.getParams().size() == 2U;
+                        check() << f.getParams().at(0) == "bar";
+                        check() << f.getParams().at(1) == "baz";
+                    })
 
-        .add_case("function_with_multiple_parameter_parsed",
-            []
-            {
-	            const FuncString f("foo(bar,baz)");
-	            check() << f.isEmpty() == false;
-	            check() << f.getName() == "foo";
-	            check() << f.getParams().size() == 2U;
-	            check() << f.getParams().at(0) == "bar";
-	            check() << f.getParams().at(1) == "baz";
-            })
+                .add_case("function_with_additional_spaces_parsed",
+                    []
+                    {
+                        const FuncString f("   foo  (  bar   ,  baz
+           )"); check() << f.isEmpty() == false; check() <<
+           f.getName() == "foo"; check() << f.getParams().size() ==
+           2U; check() << f.getParams().at(0) == "bar"; check() <<
+           f.getParams().at(1) == "baz";
+                    })
 
-        .add_case("function_with_additional_spaces_parsed",
-            []
-            {
-	            const FuncString f("   foo  (  bar   ,  baz  )");
-	            check() << f.isEmpty() == false;
-	            check() << f.getName() == "foo";
-	            check() << f.getParams().size() == 2U;
-	            check() << f.getParams().at(0) == "bar";
-	            check() << f.getParams().at(1) == "baz";
-            })
-
+                .add_case("function_with_missing_parameter_parsed",
+                    []
+                    {
+                        const FuncString f("foo(bar,,baz)");
+                        check() << f.isEmpty() == false;
+                        check() << f.getName() == "foo";
+                        check() << f.getParams().size() == 3U;
+                        check() << f.getParams().at(0) == "bar";
+                        check() << f.getParams().at(1) == "";
+                        check() << f.getParams().at(2) == "baz";
+                    })
+        */
         .add_case("function_with_one_parameter_parsed",
             []
             {
@@ -65,16 +76,14 @@ const static auto tests =
 	            check() << f.getParams().size() == 0U;
             })
 
-        .add_case("function_with_missing_parameter_parsed",
+        .add_case("function_with_parameter_contains_parenthesis",
             []
             {
-	            const FuncString f("foo(bar,,baz)");
+	            const FuncString f("foo(bar())");
 	            check() << f.isEmpty() == false;
 	            check() << f.getName() == "foo";
-	            check() << f.getParams().size() == 3U;
-	            check() << f.getParams().at(0) == "bar";
-	            check() << f.getParams().at(1) == "";
-	            check() << f.getParams().at(2) == "baz";
+	            check() << f.getParams().size() == 1U;
+	            check() << f.getParams().at(0) == "bar()";
             })
 
         .add_case("throws_on_not_matching_string",

--- a/test/unit/base/text/funcstring.cpp
+++ b/test/unit/base/text/funcstring.cpp
@@ -23,40 +23,29 @@ const static auto tests =
 	            const FuncString f("   ");
 	            check() << f.isEmpty() == true;
             })
-        /*
-                .add_case("function_with_multiple_parameter_parsed",
-                    []
-                    {
-                        const FuncString f("foo(bar,baz)");
-                        check() << f.isEmpty() == false;
-                        check() << f.getName() == "foo";
-                        check() << f.getParams().size() == 2U;
-                        check() << f.getParams().at(0) == "bar";
-                        check() << f.getParams().at(1) == "baz";
-                    })
 
-                .add_case("function_with_additional_spaces_parsed",
-                    []
-                    {
-                        const FuncString f("   foo  (  bar   ,  baz
-           )"); check() << f.isEmpty() == false; check() <<
-           f.getName() == "foo"; check() << f.getParams().size() ==
-           2U; check() << f.getParams().at(0) == "bar"; check() <<
-           f.getParams().at(1) == "baz";
-                    })
+        .add_case("function_with_multiple_parameter_parsed",
+            []
+            {
+	            const FuncString f("foo(bar,baz)");
+	            check() << f.isEmpty() == false;
+	            check() << f.getName() == "foo";
+	            check() << f.getParams().size() == 2U;
+	            check() << f.getParams().at(0) == "bar";
+	            check() << f.getParams().at(1) == "baz";
+            })
 
-                .add_case("function_with_missing_parameter_parsed",
-                    []
-                    {
-                        const FuncString f("foo(bar,,baz)");
-                        check() << f.isEmpty() == false;
-                        check() << f.getName() == "foo";
-                        check() << f.getParams().size() == 3U;
-                        check() << f.getParams().at(0) == "bar";
-                        check() << f.getParams().at(1) == "";
-                        check() << f.getParams().at(2) == "baz";
-                    })
-        */
+        .add_case("function_with_additional_spaces_parsed",
+            []
+            {
+	            const FuncString f("   foo  (  bar   ,  baz  )");
+	            check() << f.isEmpty() == false;
+	            check() << f.getName() == "foo";
+	            check() << f.getParams().size() == 2U;
+	            check() << f.getParams().at(0) == "bar";
+	            check() << f.getParams().at(1) == "baz";
+            })
+
         .add_case("function_with_one_parameter_parsed",
             []
             {
@@ -74,6 +63,18 @@ const static auto tests =
 	            check() << f.isEmpty() == false;
 	            check() << f.getName() == "foo";
 	            check() << f.getParams().size() == 0U;
+            })
+
+        .add_case("function_with_missing_parameter_parsed",
+            []
+            {
+	            const FuncString f("foo(bar,,baz)");
+	            check() << f.isEmpty() == false;
+	            check() << f.getName() == "foo";
+	            check() << f.getParams().size() == 3U;
+	            check() << f.getParams().at(0) == "bar";
+	            check() << f.getParams().at(1) == "";
+	            check() << f.getParams().at(2) == "baz";
             })
 
         .add_case("function_with_parameter_contains_parenthesis",


### PR DESCRIPTION
From this commit the "multiple argument" is unsupported, because arguments can be used ',' too