### PR TITLE
Fix invalid read/write

### DIFF
--- a/src/apps/weblib/interface.cpp
+++ b/src/apps/weblib/interface.cpp
@@ -267,25 +267,25 @@ void Interface::setAnimControlValue(ObjectRegistryHandle chart,
     const char *value)
 {
 	auto &&chartPtr = getChart(chart);
-	auto &ctrl = chartPtr->getAnimControl();
+	auto &&ctrl = chartPtr->getAnimControl();
 
-	if (path == "seek") { ctrl.seek(value); }
+	if (path == "seek") { ctrl->seek(value); }
 	else if (path == "cancel") {
-		ctrl.cancel();
+		ctrl->cancel();
 	}
 	else if (path == "stop") {
-		ctrl.stop();
+		ctrl->stop();
 	}
 	else if (auto &&set_accessor =
 	             Refl::Access::getAccessor<::Anim::Control::Option>(
 	                 path)
 	                 .set) {
-		set_accessor(ctrl.getOptions(), value);
+		set_accessor(ctrl->getOptions(), value);
 	}
 	else {
 		throw std::logic_error("invalid animation command");
 	}
-	ctrl.update();
+	ctrl->update();
 }
 
 const char *Interface::getAnimControlValue(ObjectRegistryHandle chart,
@@ -294,12 +294,12 @@ const char *Interface::getAnimControlValue(ObjectRegistryHandle chart,
 	thread_local std::string res;
 
 	auto &&chartPtr = getChart(chart);
-	auto &ctrl = chartPtr->getAnimControl();
+	auto &&ctrl = chartPtr->getAnimControl();
 
 	if (auto &&get_accessor =
 	        Refl::Access::getAccessor<::Anim::Control::Option>(path)
 	            .get) {
-		res = get_accessor(ctrl.getOptions());
+		res = get_accessor(ctrl->getOptions());
 	}
 	else
 		throw std::logic_error("invalid animation command");
@@ -396,7 +396,7 @@ void Interface::update(ObjectRegistryHandle chart, double timeInMSecs)
 	    std::chrono::duration_cast<std::chrono::nanoseconds>(
 	        std::chrono::duration<double, std::milli>{timeInMSecs});
 
-	widget->getChart().getAnimControl().update(
+	widget->getChart().getAnimControl()->update(
 	    ::Anim::TimePoint{nanoSecs});
 }
 

--- a/src/chart/main/chart.h
+++ b/src/chart/main/chart.h
@@ -54,9 +54,9 @@ public:
 	{
 		return actPlot;
 	}
-	::Anim::Control &getAnimControl()
+	std::shared_ptr<::Anim::Control> getAnimControl()
 	{
-		return animator.getControl();
+		return animator.getActAnimation();
 	}
 	Anim::AnimationPtr getAnimation()
 	{

--- a/test/qtest/window.cpp
+++ b/test/qtest/window.cpp
@@ -33,7 +33,7 @@ Window::Window(QWidget *parent) :
 void Window::animStep()
 {
 	auto now = std::chrono::steady_clock::now();
-	chart.getChart().getChart().getAnimControl().update(now);
+	chart.getChart().getChart().getAnimControl()->update(now);
 #ifndef __clang_analyzer__
 	return QTimer::singleShot(25,
 	    [this]

--- a/test/unit/chart/events.cpp
+++ b/test/unit/chart/events.cpp
@@ -383,10 +383,10 @@ std::multimap<std::string, event_as, std::less<>> get_events(
 	}
 
 	using clock_t = std::chrono::steady_clock;
-	chart.getAnimControl().update(clock_t::now());
+	chart.getAnimControl()->update(clock_t::now());
 	chart.setBoundRect(chart.getLayout().boundary);
 	chart.draw(MyCanvas{}.getCanvas());
-	chart.getAnimControl().update(clock_t::now());
+	chart.getAnimControl()->update(clock_t::now());
 
 	skip->*ends == "finished"_is_true;
 	return events;


### PR DESCRIPTION
This is because the control structure is accessed by reference, not through shared_ptr. When the `update` is called on the control structure (an Animator object), the registered callback can cause the animator to create a new Animator object that replaces the original.